### PR TITLE
feat: add Complete Session button to focus sessions

### DIFF
--- a/hide_distractions/src/content.ts
+++ b/hide_distractions/src/content.ts
@@ -234,3 +234,19 @@ window.addEventListener("show-popup-again", () => {
     }
   );
 });
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "COMPLETE_SESSION") {
+    chrome.storage.local.get("focusData", ({ focusData }) => {
+      if (focusData) {
+        const domain = message.payload?.domain;
+        if (domain && focusData[domain]) {
+          delete focusData[domain];
+          chrome.storage.local.set({ focusData });
+        }
+      }
+    });
+    window.postMessage({ type: "SESSION_COMPLETE" }, "*");
+  }
+});
+

--- a/hide_distractions/src/popup.tsx
+++ b/hide_distractions/src/popup.tsx
@@ -128,8 +128,28 @@ const App = () => {
     );
   }, []);
 
+  
+
   useEffect(() => {
-    const updateSessions = () => {
+    
+
+const handleCompleteSession = (domain: string) => {
+  chrome.storage.local.get("focusData", ({ focusData }) => {
+    if (focusData && focusData[domain]) {
+      delete focusData[domain];
+      chrome.storage.local.set({ focusData }, () => {
+        setAllFocusSessions((prev) => {
+          const updated = { ...prev };
+          delete updated[domain];
+          return updated;
+        });
+      });
+    }
+  });
+};
+
+
+const updateSessions = () => {
       chrome.storage.local.get("focusData", ({ focusData }) => {
         const sessions: Record<
           string,
@@ -298,6 +318,13 @@ const App = () => {
               {formatTime(session.timeLeft)}
               <br />
               <span className="label">{t("intention_label")}</span> {session.intention}
+              <br />
+              <button
+                className="complete-session-btn"
+                onClick={() => handleCompleteSession(domain)}
+              >
+                ✓ Complete Session
+              </button>
             </div>
           ))}
         </div>

--- a/hide_distractions/src/popup.tsx
+++ b/hide_distractions/src/popup.tsx
@@ -130,26 +130,32 @@ const App = () => {
 
   
 
-  useEffect(() => {
-    
-
-const handleCompleteSession = (domain: string) => {
-  chrome.storage.local.get("focusData", ({ focusData }) => {
-    if (focusData && focusData[domain]) {
-      delete focusData[domain];
-      chrome.storage.local.set({ focusData }, () => {
-        setAllFocusSessions((prev) => {
-          const updated = { ...prev };
-          delete updated[domain];
-          return updated;
+  const handleCompleteSession = (domain: string) => {
+    chrome.storage.local.get("focusData", ({ focusData }) => {
+      if (focusData && focusData[domain]) {
+        delete focusData[domain];
+        chrome.storage.local.set({ focusData }, async () => {
+          setAllFocusSessions((prev) => {
+            const updated = { ...prev };
+            delete updated[domain];
+            return updated;
+          });
+          const allTabs = await chrome.tabs.query({});
+          allTabs.forEach((tab) => {
+            if (tab.id && tab.url && tab.url.includes(domain)) {
+              chrome.tabs.sendMessage(tab.id, {
+                type: "COMPLETE_SESSION",
+                payload: { domain },
+              });
+            }
+          });
         });
-      });
-    }
-  });
-};
+      }
+    });
+  };
 
-
-const updateSessions = () => {
+  useEffect(() => {
+    const updateSessions = () => {
       chrome.storage.local.get("focusData", ({ focusData }) => {
         const sessions: Record<
           string,

--- a/hide_distractions/src/styles/popup.css
+++ b/hide_distractions/src/styles/popup.css
@@ -200,3 +200,26 @@ img.settings-icon {
   font-size: 14px;
   border: 1px solid #F3A650;
 }
+
+.complete-session-btn {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 8px 0;
+  background-color: #2ecc71;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.complete-session-btn:hover {
+  background-color: #27ae60;
+}
+
+.complete-session-btn:active {
+  background-color: #1e8449;
+}


### PR DESCRIPTION
## What this PR does
Adds a "Complete Session" button under each active focus session in the extension popup.

## Why
As a user, I want to be able to exit or complete a focus session so I can define when I need to move on to other tasks.

