### PR TITLE
Refactor focus session states

### DIFF
--- a/focus_bear/public/_locales/en/messages.json
+++ b/focus_bear/public/_locales/en/messages.json
@@ -47,8 +47,8 @@
     "message": "Time Left",
     "description": "Label for remaining focus session time"
   },
-  "no_focus_session": {
-    "message": "No active focus session."
+  "no_unfocus_session": {
+    "message": "No active unfocus session."
   },
   "headings": {
     "message": "Hello there! Up to mischief are we?|Caught you lurking again, didn't I?|Planning trouble, or just thinking about it?|Back for more fun, are we?|Sneaky little visit, hmm?|Stirring up chaos, or just passing through?|Oh look, it’s the mastermind again!|Plotting something brilliant... or ridiculous?|Should I be worried, or just impressed?",
@@ -102,9 +102,9 @@
     "message": "30 minutes",
     "description": "30-minute duration option"
   },
-  "settings_locked_during_session": {
-    "message": "⚠️ Settings cannot be configured during an active session.",
-    "description": "Alert shown when trying to open settings during a focus session"
+  "settings_locked_during_unfocus_session": {
+    "message": "⚠️ Settings cannot be configured during an active unfocus session.",
+    "description": "Alert shown when trying to open settings during an unfocus session"
   },
   "blur_linkedin_home": {
     "message": "Blur LinkedIn Home (coming soon)",

--- a/focus_bear/public/_locales/es/messages.json
+++ b/focus_bear/public/_locales/es/messages.json
@@ -32,8 +32,8 @@
   "time_left": {
     "message": "Tiempo restante"
   },
-  "no_focus_session": {
-    "message": "No hay una sesión de enfoque activa."
+  "no_unfocus_session": {
+    "message": "No hay una sesión de desenfoque activa."
   },
   "heading": {
     "message": "¡Hola! ¿Ya estás tramando travesuras?"
@@ -74,8 +74,8 @@
   "minute_30": {
     "message": "30 minutos"
   },
-  "settings_locked_during_session": {
-    "message": "⚠️ No se pueden configurar los ajustes durante una sesión"
+  "settings_locked_during_unfocus_session": {
+    "message": "⚠️ No se pueden configurar los ajustes durante una sesión de desenfoque"
   },
   "blur_linkedin_home": {
     "message": "Difuminar página principal de LinkedIn"

--- a/focus_bear/src/background.ts
+++ b/focus_bear/src/background.ts
@@ -14,15 +14,16 @@ chrome.runtime.onStartup.addListener(() => {
 function resetDefaults() {
   chrome.storage.local.remove(
     [
-      "focusStart",
-      "focusDuration",
-      "focusIntention",
-      "lastIntention",
-      "lastFocusDuration",
-      "focusData",
+      "unfocusStart",
+      "unfocusDuration",
+      "unfocusIntention",
+      "lastUnfocusIntention",
+      "lastUnfocusDuration",
+      "unfocusData",
+      "focusSessionState",
     ],
     () => {
-      console.log("Cleared focus session data");
+      console.log("Cleared focus & unfocus session data");
     },
   );
 
@@ -43,17 +44,18 @@ function resetDefaults() {
   );
 }
 
-// ------------------------------------------------ Pomodoro State Management ------------------------------------------------//
+// ------------------------------------------------ Focus Session State Management ------------------------------------------------//
+// The Focus Session is the primary, blocking focus state, activated by the Focus Timer.
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === "startPomodoro") {
+  if (request.action === "startFocusSession") {
     const { workDuration, breakDuration, onBreak, task } = request;
 
     const startTime = Date.now();
     const duration = onBreak ? breakDuration : workDuration;
     const endTime = startTime + duration * 1000;
 
-    const pomodoroState = {
+    const focusSessionState = {
       task: task || "",
       workDuration,
       breakDuration,
@@ -64,17 +66,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       started: true,
     };
 
-    chrome.storage.local.set({ pomodoroState }, () => {
-      console.log("Pomodoro started:", pomodoroState);
+    chrome.storage.local.set({ focusSessionState }, () => {
+      console.log("Focus Session started:", focusSessionState);
     });
 
     sendResponse({ success: true });
     return true;
   }
 
-  if (request.action === "pausePomodoro") {
-    chrome.storage.local.get("pomodoroState", (data) => {
-      const state = data.pomodoroState;
+  if (request.action === "pauseFocusSession") {
+    chrome.storage.local.get("focusSessionState", (data) => {
+      const state = data.focusSessionState;
       if (state) {
         const remaining = Math.max(Math.floor((state.endTime - Date.now()) / 1000), 0);
         const updated = {
@@ -82,8 +84,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           isRunning: false,
           timeLeft: remaining,
         };
-        chrome.storage.local.set({ pomodoroState: updated }, () => {
-          console.log("Pomodoro paused:", updated);
+        chrome.storage.local.set({ focusSessionState: updated }, () => {
+          console.log("Focus Session paused:", updated);
         });
       }
       sendResponse({ success: true });
@@ -91,20 +93,20 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true; // keep channel open for async
   }
 
-  if (request.action === "resumePomodoro") {
-    chrome.storage.local.get("pomodoroState", (data) => {
-      const prev = data.pomodoroState;
+  if (request.action === "resumeFocusSession") {
+    chrome.storage.local.get("focusSessionState", (data) => {
+      const prev = data.focusSessionState;
       if (prev && !prev.isRunning && prev.timeLeft) {
         const startTime = Date.now();
         const endTime = startTime + prev.timeLeft * 1000;
-        const pomodoroState = {
+        const focusSessionState = {
           ...prev,
           startTime,
           endTime,
           isRunning: true,
         };
-        chrome.storage.local.set({ pomodoroState }, () => {
-          console.log("Pomodoro resumed:", pomodoroState);
+        chrome.storage.local.set({ focusSessionState }, () => {
+          console.log("Focus Session resumed:", focusSessionState);
         });
       }
       sendResponse({ success: true });
@@ -112,17 +114,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 
-  if (request.action === "resetPomodoro") {
-    chrome.storage.local.remove("pomodoroState", () => {
-      console.log("Pomodoro reset");
+  if (request.action === "resetFocusSession") {
+    chrome.storage.local.remove("focusSessionState", () => {
+      console.log("Focus Session reset");
       sendResponse({ success: true });
     });
     return true;
   }
 
-  if (request.action === "getPomodoroState") {
-    chrome.storage.local.get("pomodoroState", (data) => {
-      sendResponse({ state: data.pomodoroState || null });
+  if (request.action === "getFocusSessionState") {
+    chrome.storage.local.get("focusSessionState", (data) => {
+      sendResponse({ state: data.focusSessionState || null });
     });
     return true;
   }

--- a/focus_bear/src/blocklist.ts
+++ b/focus_bear/src/blocklist.ts
@@ -39,10 +39,10 @@ async function checkBlocklist(blocklist: string[], relaxlist: string[], hours: A
   const isBlocked = blocklist.some((site) => domain.includes(site));
   const isRelaxed = relaxlist.some((site) => domain.includes(site));
 
-  const { pomodoroState } = await chrome.storage.local.get("pomodoroState");
-  const onBreak = pomodoroState?.onBreak === true;
+  const { focusSessionState } = await chrome.storage.local.get("focusSessionState");
+  const onBreak = focusSessionState?.onBreak === true;
 
-  // If on relaxlist, don't blur during pomodoro breaks
+  // If on relaxlist, don't blur during Focus Session breaks
   if (isRelaxed && onBreak) {
     removeGlobalBlur();
     return;
@@ -77,14 +77,14 @@ function runCheck() {
 // run once
 runCheck();
 
-// listen for Pomodoro timer changes
+// listen for Focus Session timer changes
 chrome.storage.onChanged.addListener(async (changes, areaName) => {
   if (areaName !== "local") return;
 
   let shouldRerun = false;
 
-  // Rerun if Pomodoro state changes
-  if (changes.pomodoroState) shouldRerun = true;
+  // Rerun if Focus Session state changes
+  if (changes.focusSessionState) shouldRerun = true;
 
   // Also rerun if blocklist, relaxlist, or activeHours change
   if (changes.blocklist || changes.relaxlist || changes.activeHours) shouldRerun = true;

--- a/focus_bear/src/components/FocusControls.tsx
+++ b/focus_bear/src/components/FocusControls.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Play, Pause, RotateCcw } from "lucide-react";
 
-interface PomodoroControlsProps {
+interface FocusControlsProps {
   isRunning: boolean;
   onPlayPause: () => void;
   onReset: () => void;
   onBreak: boolean;
 }
 
-const PomodoroControls: React.FC<PomodoroControlsProps> = ({
+const FocusControls: React.FC<FocusControlsProps> = ({
   isRunning,
   onPlayPause,
   onReset,
@@ -32,4 +32,4 @@ const PomodoroControls: React.FC<PomodoroControlsProps> = ({
   );
 };
 
-export default PomodoroControls;
+export default FocusControls;

--- a/focus_bear/src/components/FocusTimer.css
+++ b/focus_bear/src/components/FocusTimer.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 
-.pomodoro-container {
+.focus-timer-container {
   display: flex;
   justify-content: center;
   align-items: flex-start; /* stick content to the top */
@@ -9,7 +9,7 @@
   padding: 1rem 0; /* optional: keep a little breathing room */
 }
 
-.pomodoro-content {
+.focus-timer-content {
   width: 100%;
   max-width: 600px;
 }
@@ -43,7 +43,7 @@
 
 .task-input::placeholder {
   color: #535250; /* or any color you like */
-  opacity: 0.5; /* makes sure the color isn’t faded by default */
+  opacity: 0.5; /* makes sure the color isn't faded by default */
 }
 
 .breakduration-input {

--- a/focus_bear/src/components/FocusTimer.tsx
+++ b/focus_bear/src/components/FocusTimer.tsx
@@ -2,12 +2,12 @@ import React, { useState, useEffect, useRef } from "react";
 import { Play, Pause, RotateCcw } from "lucide-react";
 import CircularSlider from "./CircularSlider";
 import { IMaskInput } from "react-imask";
-import "./PomodoroTimer.css";
+import "./FocusTimer.css";
 
 const DEFAULT_WORK = 25 * 60;
 const DEFAULT_BREAK = 5 * 60;
 
-const PomodoroTimer: React.FC = () => {
+const FocusTimer: React.FC = () => {
   const [task, setTask] = useState("");
   const [workDuration, setWorkDuration] = useState(DEFAULT_WORK);
   const [breakDuration, setBreakDuration] = useState(DEFAULT_BREAK);
@@ -20,9 +20,9 @@ const PomodoroTimer: React.FC = () => {
 
   const intervalRef = useRef<number | null>(null);
 
-  // Load persisted state
+  // Load persisted Focus Session state
   useEffect(() => {
-    chrome.runtime.sendMessage({ action: "getPomodoroState" }, (response) => {
+    chrome.runtime.sendMessage({ action: "getFocusSessionState" }, (response) => {
       const saved = response?.state;
       if (saved) {
         const { task, workDuration, breakDuration, endTime, isRunning, onBreak, started } = saved;
@@ -39,6 +39,53 @@ const PomodoroTimer: React.FC = () => {
         setTimeLeft(remaining);
       }
     });
+  }, []);
+
+  // Sync with external changes to focusSessionState — e.g. when the user
+  // completes the session from the Active Sessions tab, the stored state is
+  // cleared and this listener resets the timer UI back to the setup view.
+  useEffect(() => {
+    const handler = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      areaName: string,
+    ) => {
+      if (areaName !== "local" || !changes.focusSessionState) return;
+      const next = changes.focusSessionState.newValue;
+      if (!next) {
+        // Session was cleared externally (reset/completed from Active Sessions tab)
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+        setIsRunning(false);
+        setStarted(false);
+        setOnBreak(false);
+        setManualBreakEdit(false);
+        setWorkDuration((wd) => {
+          setTimeLeft(wd);
+          const autoBreak = Math.floor(wd / 5);
+          setBreakDuration(autoBreak);
+          setBreakInput(formatTime(autoBreak));
+          return wd;
+        });
+      } else {
+        // Session state was updated externally (e.g., background phase change)
+        const { task, workDuration, breakDuration, endTime, isRunning, onBreak, started } = next;
+        const remaining = isRunning
+          ? Math.max(Math.floor((endTime - Date.now()) / 1000), 0)
+          : (next.timeLeft ?? workDuration);
+        setTask(task);
+        setWorkDuration(workDuration);
+        setBreakDuration(breakDuration);
+        setBreakInput(formatTime(breakDuration));
+        setIsRunning(isRunning);
+        setStarted(started);
+        setOnBreak(onBreak);
+        setTimeLeft(remaining);
+      }
+    };
+    chrome.storage.onChanged.addListener(handler);
+    return () => chrome.storage.onChanged.removeListener(handler);
   }, []);
 
   // Auto update break duration based on workDuration if user hasn't edited manually
@@ -98,15 +145,15 @@ const PomodoroTimer: React.FC = () => {
   };
 
   const handlePause = () => {
-    chrome.runtime.sendMessage({ action: "pausePomodoro" }, () => setIsRunning(false));
+    chrome.runtime.sendMessage({ action: "pauseFocusSession" }, () => setIsRunning(false));
   };
 
   const handleResume = () => {
-    chrome.runtime.sendMessage({ action: "resumePomodoro" }, () => setIsRunning(true));
+    chrome.runtime.sendMessage({ action: "resumeFocusSession" }, () => setIsRunning(true));
   };
 
   const handleReset = () => {
-    chrome.runtime.sendMessage({ action: "resetPomodoro" }, () => {
+    chrome.runtime.sendMessage({ action: "resetFocusSession" }, () => {
       setIsRunning(false);
       setOnBreak(false);
       setStarted(false);
@@ -121,7 +168,13 @@ const PomodoroTimer: React.FC = () => {
   const handleStart = () => {
     const finalBreak = commitBreakInput();
     chrome.runtime.sendMessage(
-      { action: "startPomodoro", workDuration, breakDuration: finalBreak, task, onBreak: false },
+      {
+        action: "startFocusSession",
+        workDuration,
+        breakDuration: finalBreak,
+        task,
+        onBreak: false,
+      },
       () => {
         setIsRunning(true);
         setStarted(true);
@@ -135,8 +188,8 @@ const PomodoroTimer: React.FC = () => {
   const progress = onBreak ? 1 - timeLeft / breakDuration : 1 - timeLeft / workDuration;
 
   return (
-    <div className="pomodoro-container">
-      <div className="pomodoro-content">
+    <div className="focus-timer-container">
+      <div className="focus-timer-content">
         <div className="task-input-container">
           <input
             type="text"
@@ -242,4 +295,4 @@ const PomodoroTimer: React.FC = () => {
   );
 };
 
-export default PomodoroTimer;
+export default FocusTimer;

--- a/focus_bear/src/content.ts
+++ b/focus_bear/src/content.ts
@@ -41,11 +41,11 @@ window.addEventListener("message", (event) => {
   }
 });
 
-// Inject popup on first visit if no domain session exists
-chrome.storage.local.get(["focusData"], ({ focusData }) => {
-  const session = focusData?.[domain];
+// Inject popup on first visit if no domain Unfocus Session exists
+chrome.storage.local.get(["unfocusData"], ({ unfocusData }) => {
+  const session = unfocusData?.[domain];
   if (!session) {
-    console.log(`[Content] No session found for ${domain}, injecting popup`);
+    console.log(`[Content] No unfocus session found for ${domain}, injecting popup`);
     if (!document.getElementById("intention-popup-script")) {
       const script = document.createElement("script");
       script.src = chrome.runtime.getURL("floatingPopup.js");
@@ -56,8 +56,8 @@ chrome.storage.local.get(["focusData"], ({ focusData }) => {
           {
             type: "INIT_INTENTION_DATA",
             payload: {
-              lastIntention: "",
-              lastFocusDuration: 0,
+              lastUnfocusIntention: "",
+              lastUnfocusDuration: 0,
             },
           },
           "*",
@@ -66,32 +66,32 @@ chrome.storage.local.get(["focusData"], ({ focusData }) => {
       document.body.appendChild(script);
     }
   } else {
-    console.log(`[Content] Session already exists for ${domain}, no popup needed.`);
+    console.log(`[Content] Unfocus session already exists for ${domain}, no popup needed.`);
   }
 });
 
-// Domain-specific timer scheduling
-chrome.storage.local.get(["focusData"], ({ focusData }) => {
-  const session = focusData?.[domain];
+// Domain-specific timer scheduling for Unfocus Sessions
+chrome.storage.local.get(["unfocusData"], ({ unfocusData }) => {
+  const session = unfocusData?.[domain];
 
-  if (session?.focusStart && session?.focusDuration) {
-    const elapsed = Date.now() - session.focusStart;
-    const totalMs = session.focusDuration * 60 * 1000;
+  if (session?.unfocusStart && session?.unfocusDuration) {
+    const elapsed = Date.now() - session.unfocusStart;
+    const totalMs = session.unfocusDuration * 60 * 1000;
     const remaining = totalMs - elapsed;
 
     if (remaining > 0) {
-      console.log(`[Content] [${domain}] Scheduling re-popup in ${remaining}ms`);
+      console.log(`[Content] [${domain}] Scheduling unfocus re-popup in ${remaining}ms`);
       setTimeout(() => {
         const currentDomain = window.location.hostname.replace(/^www\./, "");
         if (currentDomain === domain) {
-          console.log(`[Content] [${domain}] Timer expired → showing popup`);
+          console.log(`[Content] [${domain}] Unfocus timer expired → showing popup`);
           window.dispatchEvent(new CustomEvent("show-popup-again"));
         } else {
           console.log(`[Content] Skipping popup: tab is on ${currentDomain}, not ${domain}`);
         }
       }, remaining);
     } else {
-      console.log(`[Content] [${domain}] Timer already expired — showing popup now`);
+      console.log(`[Content] [${domain}] Unfocus timer already expired — showing popup now`);
       window.dispatchEvent(new CustomEvent("show-popup-again"));
     }
   }
@@ -102,7 +102,7 @@ window.addEventListener("show-popup-again", () => {
   console.log("[Content] show-popup-again event fired, attempting reinjection…");
 });
 
-let focusTimer: ReturnType<typeof setTimeout> | null = null;
+let unfocusTimer: ReturnType<typeof setTimeout> | null = null;
 // oxlint-disable-next-line no-unused-vars
 let isBlurEnabled = true;
 
@@ -115,40 +115,40 @@ window.addEventListener("message", (event) => {
     window.dispatchEvent(customEvent);
   }
 
-  if (event.data.type === "STORE_FOCUS_DATA") {
-    const { focusStart, focusDuration, focusIntention } = event.data.payload;
+  if (event.data.type === "STORE_UNFOCUS_DATA") {
+    const { unfocusStart, unfocusDuration, unfocusIntention } = event.data.payload;
     chrome.storage.local.set(
       {
-        focusStart,
-        focusDuration,
-        focusIntention,
+        unfocusStart,
+        unfocusDuration,
+        unfocusIntention,
         showIntentionPopup: false,
-        lastIntention: focusIntention,
-        lastFocusDuration: focusDuration,
+        lastUnfocusIntention: unfocusIntention,
+        lastUnfocusDuration: unfocusDuration,
       },
       () => {
-        console.log("Stored focus session & hid popup permanently");
+        console.log("Stored unfocus session & hid popup permanently");
 
         // ─── schedule the popup in this tab right now ───
-        const elapsed = Date.now() - focusStart;
-        const totalMs = focusDuration * 60 * 1000;
+        const elapsed = Date.now() - unfocusStart;
+        const totalMs = unfocusDuration * 60 * 1000;
         const remaining = totalMs - elapsed;
 
         if (remaining > 0) {
-          console.log(`[Content] [STORE] Scheduling re-popup in ${remaining}ms`);
+          console.log(`[Content] [STORE] Scheduling unfocus re-popup in ${remaining}ms`);
           setTimeout(() => {
             const currentDomain = window.location.hostname.replace(/^www\./, "");
             if (currentDomain === domain) {
-              console.log(`[STORE] Timer expired for ${domain} → showing popup`);
+              console.log(`[STORE] Unfocus timer expired for ${domain} → showing popup`);
               window.dispatchEvent(new CustomEvent("show-popup-again"));
             } else {
               console.log(
-                `[STORE] Timer expired for ${domain}, but user is on ${currentDomain} → ignoring`,
+                `[STORE] Unfocus timer expired for ${domain}, but user is on ${currentDomain} → ignoring`,
               );
             }
           }, remaining);
         } else {
-          console.log("[Content] [STORE] Timer already expired; showing now");
+          console.log("[Content] [STORE] Unfocus timer already expired; showing now");
           window.dispatchEvent(new CustomEvent("show-popup-again"));
         }
       },
@@ -167,39 +167,39 @@ window.addEventListener("message", (event) => {
     window.dispatchEvent(customEvent);
   }
 
-  if (event.data.type === "START_FOCUS_TIMER") {
+  if (event.data.type === "START_UNFOCUS_TIMER") {
     const durationInMinutes = event.data.payload;
 
-    if (focusTimer) clearTimeout(focusTimer);
+    if (unfocusTimer) clearTimeout(unfocusTimer);
 
-    console.log(`Starting focus timer for ${durationInMinutes} minutes.`);
-    focusTimer = setTimeout(
+    console.log(`Starting unfocus timer for ${durationInMinutes} minutes.`);
+    unfocusTimer = setTimeout(
       () => {
-        console.log("Focus timer ended. Dispatching SHOW_POPUP event.");
+        console.log("Unfocus timer ended. Dispatching SHOW_POPUP event.");
         window.dispatchEvent(new CustomEvent("show-popup-again"));
       },
       durationInMinutes * 60 * 1000,
     );
   }
 
-  // NEW: Save focus data to chrome.storage.local
-  if (event.data.type === "STORE_FOCUS_DATA") {
-    const { focusStart, focusDuration, focusIntention } = event.data.payload;
+  // NEW: Save unfocus data to chrome.storage.local
+  if (event.data.type === "STORE_UNFOCUS_DATA") {
+    const { unfocusStart, unfocusDuration, unfocusIntention } = event.data.payload;
     const domain = window.location.hostname.replace(/^www\./, "");
-    console.log(`[STORE_FOCUS_DATA] domain: ${domain}`);
+    console.log(`[STORE_UNFOCUS_DATA] domain: ${domain}`);
 
-    chrome.storage.local.get(["focusData"], (result) => {
-      const focusData = result.focusData || {};
+    chrome.storage.local.get(["unfocusData"], (result) => {
+      const unfocusData = result.unfocusData || {};
 
-      focusData[domain] = {
-        focusStart,
-        focusDuration,
-        focusIntention,
+      unfocusData[domain] = {
+        unfocusStart,
+        unfocusDuration,
+        unfocusIntention,
       };
 
-      chrome.storage.local.set({ focusData }, () => {
-        console.log(`✅ Stored focus session for ${domain}`);
-        console.log("focusData is now:", focusData);
+      chrome.storage.local.set({ unfocusData }, () => {
+        console.log(`✅ Stored unfocus session for ${domain}`);
+        console.log("unfocusData is now:", unfocusData);
       });
     });
   }
@@ -208,8 +208,8 @@ window.addEventListener("message", (event) => {
 window.addEventListener("show-popup-again", () => {
   // fetch only the data we need for pre-filling the form:
   chrome.storage.local.get(
-    ["lastIntention", "lastFocusDuration"],
-    ({ lastIntention, lastFocusDuration }) => {
+    ["lastUnfocusIntention", "lastUnfocusDuration"],
+    ({ lastUnfocusIntention, lastUnfocusDuration }) => {
       // never inject twice
       if (document.getElementById("intention-popup-script")) {
         return;
@@ -226,7 +226,7 @@ window.addEventListener("show-popup-again", () => {
         window.postMessage(
           {
             type: "INIT_INTENTION_DATA",
-            payload: { lastIntention, lastFocusDuration },
+            payload: { lastUnfocusIntention, lastUnfocusDuration },
           },
           "*",
         );
@@ -238,16 +238,16 @@ window.addEventListener("show-popup-again", () => {
 });
 
 chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === "COMPLETE_SESSION") {
-    chrome.storage.local.get("focusData", ({ focusData }) => {
-      if (focusData) {
+  if (message.type === "COMPLETE_UNFOCUS_SESSION") {
+    chrome.storage.local.get("unfocusData", ({ unfocusData }) => {
+      if (unfocusData) {
         const domain = message.payload?.domain;
-        if (domain && focusData[domain]) {
-          delete focusData[domain];
-          chrome.storage.local.set({ focusData });
+        if (domain && unfocusData[domain]) {
+          delete unfocusData[domain];
+          chrome.storage.local.set({ unfocusData });
         }
       }
     });
-    window.postMessage({ type: "SESSION_COMPLETE" }, "*");
+    window.postMessage({ type: "UNFOCUS_SESSION_COMPLETE" }, "*");
   }
 });

--- a/focus_bear/src/context/intentionPopupContext.tsx
+++ b/focus_bear/src/context/intentionPopupContext.tsx
@@ -10,8 +10,8 @@ interface IntentionContextProps {
   setTimeLeft: (seconds: number) => void;
   timerActive: boolean;
   setTimerActive: (active: boolean) => void;
-  startFocusTimer: (minutes: number) => void;
-  stopFocusTimer: () => void;
+  startUnfocusTimer: (minutes: number) => void;
+  stopUnfocusTimer: () => void;
 }
 
 const IntentionContext = createContext<IntentionContextProps>({
@@ -24,8 +24,8 @@ const IntentionContext = createContext<IntentionContextProps>({
   setTimeLeft: () => {},
   timerActive: false,
   setTimerActive: () => {},
-  startFocusTimer: () => {},
-  stopFocusTimer: () => {},
+  startUnfocusTimer: () => {},
+  stopUnfocusTimer: () => {},
 });
 
 export const IntentionProvider = ({ children }: { children: ReactNode }) => {
@@ -56,7 +56,7 @@ export const IntentionProvider = ({ children }: { children: ReactNode }) => {
     };
   }, []);
 
-  const startFocusTimer = (minutes: number) => {
+  const startUnfocusTimer = (minutes: number) => {
     if (intervalRef.current) clearInterval(intervalRef.current);
 
     const totalSeconds = minutes * 60;
@@ -65,9 +65,9 @@ export const IntentionProvider = ({ children }: { children: ReactNode }) => {
     setTimerActive(true);
 
     chrome.storage.local.set({
-      focusStart: Date.now(),
-      focusDuration: minutes,
-      focusIntention: intention,
+      unfocusStart: Date.now(),
+      unfocusDuration: minutes,
+      unfocusIntention: intention,
     });
 
     intervalRef.current = setInterval(() => {
@@ -76,7 +76,7 @@ export const IntentionProvider = ({ children }: { children: ReactNode }) => {
           clearInterval(intervalRef.current!);
           intervalRef.current = null;
           setTimerActive(false);
-          chrome.storage.local.remove(["focusStart", "focusDuration", "focusIntention"]);
+          chrome.storage.local.remove(["unfocusStart", "unfocusDuration", "unfocusIntention"]);
           window.dispatchEvent(new CustomEvent("show-popup-again"));
           return 0;
         }
@@ -85,7 +85,7 @@ export const IntentionProvider = ({ children }: { children: ReactNode }) => {
     }, 1000);
   };
 
-  const stopFocusTimer = () => {
+  const stopUnfocusTimer = () => {
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
@@ -109,8 +109,8 @@ export const IntentionProvider = ({ children }: { children: ReactNode }) => {
         setTimeLeft,
         timerActive,
         setTimerActive,
-        startFocusTimer,
-        stopFocusTimer,
+        startUnfocusTimer,
+        stopUnfocusTimer,
       }}
     >
       {children}

--- a/focus_bear/src/context/unfocusTimer.ts
+++ b/focus_bear/src/context/unfocusTimer.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 
-interface FocusSession {
-  focusStart: number;
-  focusDuration: number; // in minutes
-  focusIntention: string;
+interface UnfocusSession {
+  unfocusStart: number;
+  unfocusDuration: number; // in minutes
+  unfocusIntention: string;
 }
 
-export const useFocusTimer = () => {
+export const useUnfocusTimer = () => {
   const [intention, setIntention] = useState("");
   const [timeLeft, setTimeLeft] = useState(0);
   const [timerActive, setTimerActive] = useState(false);
@@ -14,18 +14,18 @@ export const useFocusTimer = () => {
 
   const restoreFromStorage = () => {
     chrome.storage.local.get(
-      ["focusStart", "focusDuration", "focusIntention"],
-      (result: FocusSession) => {
-        const { focusStart, focusDuration, focusIntention } = result;
+      ["unfocusStart", "unfocusDuration", "unfocusIntention"],
+      (result: UnfocusSession) => {
+        const { unfocusStart, unfocusDuration, unfocusIntention } = result;
 
-        if (!focusStart || !focusDuration) return;
+        if (!unfocusStart || !unfocusDuration) return;
 
-        const elapsed = Math.floor((Date.now() - focusStart) / 1000);
-        const totalSeconds = focusDuration * 60;
+        const elapsed = Math.floor((Date.now() - unfocusStart) / 1000);
+        const totalSeconds = unfocusDuration * 60;
         const remaining = totalSeconds - elapsed;
 
         if (remaining > 0) {
-          setIntention(focusIntention || "");
+          setIntention(unfocusIntention || "");
           setTimeLeft(remaining);
           setTimerActive(true);
 
@@ -35,7 +35,11 @@ export const useFocusTimer = () => {
               if (prev <= 1) {
                 clearInterval(intervalRef.current!);
                 setTimerActive(false);
-                chrome.storage.local.remove(["focusStart", "focusDuration", "focusIntention"]);
+                chrome.storage.local.remove([
+                  "unfocusStart",
+                  "unfocusDuration",
+                  "unfocusIntention",
+                ]);
                 return 0;
               }
               return prev - 1;

--- a/focus_bear/src/global.d.ts
+++ b/focus_bear/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/focus_bear/src/intentionPopup.tsx
+++ b/focus_bear/src/intentionPopup.tsx
@@ -94,9 +94,9 @@ const IntentionPopup = () => {
       if (event.source !== window) return;
       if (event.data?.type !== "INIT_INTENTION_DATA") return;
 
-      const { lastIntention, lastFocusDuration } = event.data.payload;
-      if (lastIntention) setIntention(lastIntention);
-      if (typeof lastFocusDuration === "number") setTimer(lastFocusDuration);
+      const { lastUnfocusIntention, lastUnfocusDuration } = event.data.payload;
+      if (lastUnfocusIntention) setIntention(lastUnfocusIntention);
+      if (typeof lastUnfocusDuration === "number") setTimer(lastUnfocusDuration);
       setVisible(true);
       setRandomHeading(headings[Math.floor(Math.random() * headings.length)]);
       setRandomPrompt(prompts[Math.floor(Math.random() * prompts.length)]);
@@ -109,22 +109,22 @@ const IntentionPopup = () => {
   }, []);
 
   const handleSave = () => {
-    const focusDuration = timer;
-    const focusStart = Date.now();
+    const unfocusDuration = timer;
+    const unfocusStart = Date.now();
 
     window.postMessage(
       {
-        type: "STORE_FOCUS_DATA",
+        type: "STORE_UNFOCUS_DATA",
         payload: {
           domain: window.location.hostname,
-          focusStart,
-          focusDuration,
-          focusIntention: intention,
+          unfocusStart,
+          unfocusDuration,
+          unfocusIntention: intention,
         },
       },
       "*",
     );
-    window.postMessage({ type: "START_FOCUS_TIMER", payload: timer }, "*");
+    window.postMessage({ type: "START_UNFOCUS_TIMER", payload: timer }, "*");
 
     setVisible(false);
   };

--- a/focus_bear/src/popup.tsx
+++ b/focus_bear/src/popup.tsx
@@ -5,7 +5,7 @@ import iconUrl from "../public/icons/bearLogo.png";
 import setIcon from "../public/icons/settingsIcon.png";
 
 import "@radix-ui/themes/styles.css";
-import PomodoroTimer from "./components/PomodoroTimer";
+import FocusTimer from "./components/FocusTimer";
 
 const Toggle = ({
   checked,
@@ -270,13 +270,20 @@ const App = () => {
   const [promotionBlurEnabled, setPromotionBlurEnabled] = useState(true);
   const [socialBlurEnabled, setSocialBlurEnabled] = useState(true);
 
-  const [currentTab, setCurrentTab] = useState<"pomodoro" | "focus">("pomodoro");
+  const [currentTab, setCurrentTab] = useState<"timer" | "active">("timer");
 
   const [showBlocklist, setShowBlocklist] = useState(false);
 
-  const [allFocusSessions, setAllFocusSessions] = useState<
+  const [allUnfocusSessions, setAllUnfocusSessions] = useState<
     Record<string, { intention: string; timeLeft: number }>
   >({});
+
+  const [activeFocusSession, setActiveFocusSession] = useState<{
+    task: string;
+    phase: "focus" | "break";
+    timeLeft: number;
+    isRunning: boolean;
+  } | null>(null);
 
   useEffect(() => {
     chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
@@ -374,12 +381,12 @@ const App = () => {
     });
   }, []);
 
-  const handleCompleteSession = (domain: string) => {
-    chrome.storage.local.get("focusData", ({ focusData }) => {
-      if (focusData && focusData[domain]) {
-        delete focusData[domain];
-        chrome.storage.local.set({ focusData }, async () => {
-          setAllFocusSessions((prev) => {
+  const handleCompleteUnfocusSession = (domain: string) => {
+    chrome.storage.local.get("unfocusData", ({ unfocusData }) => {
+      if (unfocusData && unfocusData[domain]) {
+        delete unfocusData[domain];
+        chrome.storage.local.set({ unfocusData }, async () => {
+          setAllUnfocusSessions((prev) => {
             const updated = { ...prev };
             delete updated[domain];
             return updated;
@@ -388,7 +395,7 @@ const App = () => {
           allTabs.forEach((tab) => {
             if (tab.id && tab.url && tab.url.includes(domain)) {
               chrome.tabs.sendMessage(tab.id, {
-                type: "COMPLETE_SESSION",
+                type: "COMPLETE_UNFOCUS_SESSION",
                 payload: { domain },
               });
             }
@@ -398,32 +405,56 @@ const App = () => {
     });
   };
 
+  const handleCompleteFocusSession = () => {
+    chrome.runtime.sendMessage({ action: "resetFocusSession" }, () => {
+      setActiveFocusSession(null);
+    });
+  };
+
   useEffect(() => {
     const updateSessions = () => {
-      chrome.storage.local.get("focusData", ({ focusData }) => {
+      chrome.storage.local.get(["unfocusData", "focusSessionState"], (data) => {
+        const { unfocusData, focusSessionState } = data;
         const sessions: Record<string, { intention: string; timeLeft: number }> = {};
         const now = Date.now();
 
-        if (focusData) {
-          Object.entries(focusData).forEach(([domain, data]: [string, any]) => {
-            const { focusStart, focusDuration, focusIntention } = data;
-            const end = focusStart + focusDuration * 60 * 1000;
+        if (unfocusData) {
+          Object.entries(unfocusData).forEach(([domain, data]: [string, any]) => {
+            const { unfocusStart, unfocusDuration, unfocusIntention } = data;
+            const end = unfocusStart + unfocusDuration * 60 * 1000;
             const timeLeft = Math.floor((end - now) / 1000);
 
             if (timeLeft > 0) {
               sessions[domain] = {
-                intention: focusIntention,
+                intention: unfocusIntention,
                 timeLeft,
               };
             }
           });
         }
 
-        setAllFocusSessions(sessions);
+        setAllUnfocusSessions(sessions);
+
+        // Derive active Focus Session display state
+        if (focusSessionState && focusSessionState.started) {
+          const { task, workDuration, breakDuration, endTime, isRunning, onBreak } =
+            focusSessionState;
+          const phaseDuration = onBreak ? breakDuration : workDuration;
+          const timeLeft = isRunning
+            ? Math.max(Math.floor((endTime - now) / 1000), 0)
+            : (focusSessionState.timeLeft ?? phaseDuration);
+          setActiveFocusSession({
+            task: task || "",
+            phase: onBreak ? "break" : "focus",
+            timeLeft,
+            isRunning: !!isRunning,
+          });
+        } else {
+          setActiveFocusSession(null);
+        }
       });
     };
 
-    console.log("sessions", allFocusSessions);
     updateSessions(); // first load
     const interval = setInterval(updateSessions, 1000); // update every second
     return () => clearInterval(interval);
@@ -652,49 +683,92 @@ const App = () => {
       {/* Tab buttons */}
       <div className="tab-buttons">
         <button
-          className={`tab-button ${currentTab === "pomodoro" ? "active" : ""}`}
-          onClick={() => setCurrentTab("pomodoro")}
+          className={`tab-button ${currentTab === "timer" ? "active" : ""}`}
+          onClick={() => setCurrentTab("timer")}
         >
-          Pomodoro
+          Focus Timer
         </button>
         <button
-          className={`tab-button ${currentTab === "focus" ? "active" : ""}`}
-          onClick={() => setCurrentTab("focus")}
+          className={`tab-button ${currentTab === "active" ? "active" : ""}`}
+          onClick={() => setCurrentTab("active")}
         >
-          Focus Sessions
+          Active Sessions
+          {(activeFocusSession ? 1 : 0) + Object.keys(allUnfocusSessions).length > 0 && (
+            <span className="tab-badge">
+              {(activeFocusSession ? 1 : 0) + Object.keys(allUnfocusSessions).length}
+            </span>
+          )}
         </button>
       </div>
       {/* Tab content */}
-      {currentTab === "pomodoro" && (
-        <div className="pomodoro_player" style={{ backgroundColor: "#fffcf6" }}>
-          <PomodoroTimer />
+      {currentTab === "timer" && (
+        <div className="focus_session_player" style={{ backgroundColor: "#fffcf6" }}>
+          <FocusTimer />
         </div>
       )}
-      `
-      {currentTab === "focus" && (
-        <div>
-          {Object.keys(allFocusSessions).length > 0 ? (
-            <div className="session-list">
-              {Object.entries(allFocusSessions).map(([domain, session]) => (
-                <div key={domain} className="session-card">
-                  <strong className="domain">{domain}</strong>
-                  <br />
-                  <span className="label">{t("time_left")}</span> {formatTime(session.timeLeft)}
-                  <br />
-                  <span className="label">{t("intention_label")}</span> {session.intention}
-                  <br />
-                  <button
-                    className="complete-session-btn"
-                    onClick={() => handleCompleteSession(domain)}
-                  >
-                    ✓ Complete Session
-                  </button>
+      {currentTab === "active" && (
+        <div className="active-sessions">
+          <section className="session-section">
+            <h3 className="session-section-title">Focus Session</h3>
+            {activeFocusSession ? (
+              <div className="session-card focus-session-card">
+                <div className="session-card-header">
+                  <span className={`phase-badge phase-${activeFocusSession.phase}`}>
+                    {activeFocusSession.phase === "focus" ? "Focusing" : "On Break"}
+                  </span>
+                  {!activeFocusSession.isRunning && (
+                    <span className="phase-badge phase-paused">Paused</span>
+                  )}
                 </div>
-              ))}
-            </div>
-          ) : (
-            <p className="no-session">{t("no_focus_session")}</p>
-          )}
+                {activeFocusSession.task && (
+                  <div className="session-row">
+                    <span className="label">Task:</span>
+                    <span className="session-task">{activeFocusSession.task}</span>
+                  </div>
+                )}
+                <div className="session-row">
+                  <span className="label">{t("time_left")}</span>
+                  <span className="session-time">{formatTime(activeFocusSession.timeLeft)}</span>
+                </div>
+                <button className="complete-session-btn" onClick={handleCompleteFocusSession}>
+                  ✓ Complete Session
+                </button>
+              </div>
+            ) : (
+              <p className="no-session">No focus session running</p>
+            )}
+          </section>
+
+          <section className="session-section">
+            <h3 className="session-section-title">Unfocus Sessions</h3>
+            {Object.keys(allUnfocusSessions).length > 0 ? (
+              <div className="session-list">
+                {Object.entries(allUnfocusSessions).map(([domain, session]) => (
+                  <div key={domain} className="session-card unfocus-session-card">
+                    <div className="session-card-header">
+                      <strong className="domain">{domain}</strong>
+                    </div>
+                    <div className="session-row">
+                      <span className="label">{t("time_left")}</span>
+                      <span className="session-time">{formatTime(session.timeLeft)}</span>
+                    </div>
+                    <div className="session-row">
+                      <span className="label">{t("intention_label")}</span>
+                      <span className="session-intention">{session.intention}</span>
+                    </div>
+                    <button
+                      className="complete-session-btn"
+                      onClick={() => handleCompleteUnfocusSession(domain)}
+                    >
+                      ✓ Complete Session
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="no-session">{t("no_unfocus_session")}</p>
+            )}
+          </section>
         </div>
       )}
       <img
@@ -702,7 +776,7 @@ const App = () => {
         alt="Settings Icon"
         className="settings-icon"
         onClick={() => {
-          if (currentDomain && allFocusSessions[currentDomain]) {
+          if (currentDomain && allUnfocusSessions[currentDomain]) {
             setSettingsBlockedMessage(true);
             setTimeout(() => setSettingsBlockedMessage(false), 3000); // hide after 3 sec
           } else {
@@ -711,7 +785,7 @@ const App = () => {
         }}
       />
       {settingsBlockedMessage && (
-        <p className="settings-warning">{t("settings_locked_during_session")}</p>
+        <p className="settings-warning">{t("settings_locked_during_unfocus_session")}</p>
       )}
     </div>
   );

--- a/focus_bear/src/styles/popup.css
+++ b/focus_bear/src/styles/popup.css
@@ -160,7 +160,8 @@ button.close-button:disabled {
 
 /* Session Cards Container */
 .session-list {
-  max-height: 160px; /* fits 2–3 cards depending on content */
+  max-height: 160px;
+  /* fits 2–3 cards depending on content */
   overflow-y: auto;
   margin-top: 20px;
 }
@@ -436,4 +437,128 @@ img.settings-icon {
   border-color: #aaa;
   color: #666;
   cursor: not-allowed;
+}
+
+/*  Active Sessions */
+.active-sessions {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.session-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.session-section-title {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #5a2c00;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #e0b991;
+}
+
+/* Distinguish focus vs unfocus cards with a left accent bar */
+.focus-session-card {
+  border-left: 4px solid #e9902c;
+}
+
+.unfocus-session-card {
+  border-left: 4px solid #b68c5a;
+}
+
+/* Override session-list max-height in the active view — it's already scoped by parent */
+.active-sessions .session-list {
+  max-height: 220px;
+  margin-top: 0;
+}
+
+.session-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.session-card .session-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 2px 0;
+}
+
+.session-task {
+  font-weight: 600;
+  color: #5a2c00;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-time {
+  font-family: monospace;
+  font-weight: 700;
+  color: #5a2c00;
+  font-size: 16px;
+}
+
+.session-intention {
+  color: #5a2c00;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.phase-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: #fffcf6;
+}
+
+.phase-focus {
+  background-color: #e9902c;
+}
+
+.phase-break {
+  background-color: #6aa36a;
+}
+
+.phase-paused {
+  background-color: #8a8a8a;
+}
+
+/* Count badge on the Active Sessions tab */
+.tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  margin-left: 6px;
+  border-radius: 999px;
+  background-color: #e9902c;
+  color: #fffcf6;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.session-section .no-session {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: #8a6640;
+  font-style: italic;
+  text-align: center;
 }


### PR DESCRIPTION
**Main Changes**
- Renamed Pomodoro Timer to Focus Timer
- Added distinctive focus sessions:
'Focus Session' - Started from focus timer, represents the primary blocking focus state.
'Unfocused Session' - Started from the distracting website popup, represents the targeted less-blocking focus state.
- Added both of the above sessions to the active sessions tab.
- Refactored the in-code references to the above.