### PR TITLE
US51/fix linkedIn News/Today's puzzle + notification badge distraction toggle

### DIFF
--- a/focus_bear/public/_locales/en/messages.json
+++ b/focus_bear/public/_locales/en/messages.json
@@ -31,6 +31,10 @@
     "message": "Blur News",
     "description": "Option to blur trending news"
   },
+  "remove_badges": {
+    "message": "Remove Notifications",
+    "description": "Option to remove LinkedIn notification badges"
+  },
   "intention_label": {
     "message": "Intention",
     "description": "Label for user intention input"

--- a/focus_bear/public/_locales/es/messages.json
+++ b/focus_bear/public/_locales/es/messages.json
@@ -23,6 +23,9 @@
   "blur_news": {
     "message": "Noticias borrosas"
   },
+  "remove_badges": {
+    "message": "Quitar notificaciones"
+  },
   "blur_jobs": {
     "message": "Difuminar sugerencias de empleo"
   },

--- a/focus_bear/src/background.ts
+++ b/focus_bear/src/background.ts
@@ -36,6 +36,7 @@ function resetDefaults() {
       homePageBlurEnabled: true,
       shortsBlurEnabled: true,
       linkedinBlurNews: true,
+      linkedinRemoveBadges: true,
       linkedinBlurHome: true,
     },
     () => console.log("Defaults reset on install/startup"),

--- a/focus_bear/src/linkedin/linkedin.ts
+++ b/focus_bear/src/linkedin/linkedin.ts
@@ -51,10 +51,7 @@
       let current: HTMLElement | null = node;
       for (let i = 0; i < 8 && current; i += 1) {
         const text = (current.textContent || "").toLowerCase();
-        if (
-          isLikelyNewsCard(current) &&
-          evidenceTerms.some((term) => text.includes(term))
-        ) {
+        if (isLikelyNewsCard(current) && evidenceTerms.some((term) => text.includes(term))) {
           candidates.push(current);
           break;
         }
@@ -90,9 +87,7 @@
   };
 
   const setBlurNews = (enabled: boolean) => {
-    const current = Array.from(
-      document.querySelectorAll<HTMLElement>(`[${NEWS_MARKER}="1"]`),
-    );
+    const current = Array.from(document.querySelectorAll<HTMLElement>(`[${NEWS_MARKER}="1"]`));
     if (!enabled) {
       if (current.length > 0) clearNewsBlur();
       return;

--- a/focus_bear/src/linkedin/linkedin.ts
+++ b/focus_bear/src/linkedin/linkedin.ts
@@ -33,27 +33,27 @@
     return rightSide && cardLikeSize;
   };
 
-  /** Find only the LinkedIn News card in the right rail (not the whole page/sidebar). */
-  const findNewsContainer = (): HTMLElement | null => {
-    if (!isHomeFeed()) return null;
+  const findRailCardsByHeading = (headings: string[], evidenceTerms: string[]) => {
+    if (!isHomeFeed()) return [] as HTMLElement[];
 
-    // Text-first targeting: find nodes whose own textContent contains "LinkedIn News".
+    // Text-first targeting in right rail; then walk up to nearest card-like ancestor.
     const baseNodes = Array.from(
       document.querySelectorAll<HTMLElement>("div, section, aside"),
-    ).filter((el) => (el.textContent || "").includes("LinkedIn News"));
-    if (baseNodes.length === 0) return null;
+    ).filter((el) => {
+      const text = (el.textContent || "").toLowerCase();
+      return headings.some((heading) => text.includes(heading));
+    });
+    if (baseNodes.length === 0) return [] as HTMLElement[];
 
     const candidates: HTMLElement[] = [];
     baseNodes.forEach((node) => {
-      // Walk up to a card-like ancestor and keep the first good match.
+      // Walk up to a card-like ancestor and keep the first good match for this text node.
       let current: HTMLElement | null = node;
-      for (let i = 0; i < 6 && current; i += 1) {
+      for (let i = 0; i < 8 && current; i += 1) {
         const text = (current.textContent || "").toLowerCase();
         if (
           isLikelyNewsCard(current) &&
-          (text.includes("top stories") ||
-            text.includes("show more news") ||
-            text.includes("today's puzzles"))
+          evidenceTerms.some((term) => text.includes(term))
         ) {
           candidates.push(current);
           break;
@@ -62,10 +62,24 @@
       }
     });
 
-    if (candidates.length === 0) return null;
-    return candidates.sort(
-      (a, b) => a.clientWidth * a.clientHeight - b.clientWidth * b.clientHeight,
-    )[0];
+    if (candidates.length === 0) return [] as HTMLElement[];
+
+    // De-dupe by element identity and sort to keep output stable.
+    const unique = Array.from(new Set(candidates));
+    return unique.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
+  };
+
+  /** Find right-rail modules blurred by "Blur News": LinkedIn News + Today's puzzles. */
+  const findNewsTargets = (): HTMLElement[] => {
+    const newsCards = findRailCardsByHeading(
+      ["linkedin news"],
+      ["linkedin news", "top stories", "show more news"],
+    );
+    const puzzleCards = findRailCardsByHeading(
+      ["today's puzzles", "todays puzzles"],
+      ["today's puzzles", "todays puzzles", "patches #", "zip #", "mini sudoku #", "tango #"],
+    );
+    return Array.from(new Set([...newsCards, ...puzzleCards]));
   };
 
   const clearNewsBlur = () => {
@@ -76,22 +90,33 @@
   };
 
   const setBlurNews = (enabled: boolean) => {
-    const current = document.querySelector<HTMLElement>(`[${NEWS_MARKER}="1"]`);
+    const current = Array.from(
+      document.querySelectorAll<HTMLElement>(`[${NEWS_MARKER}="1"]`),
+    );
     if (!enabled) {
-      if (current) clearNewsBlur();
+      if (current.length > 0) clearNewsBlur();
       return;
     }
 
-    const node = findNewsContainer();
-    if (!node) return;
-
-    // Keep blur stable: only switch DOM state if target changed.
-    if (current && current !== node) {
-      current.classList.remove(BLUR_CLASS);
-      current.removeAttribute(NEWS_MARKER);
+    const targets = findNewsTargets();
+    if (targets.length === 0) {
+      // Avoid stale blur when LinkedIn re-renders or route changes.
+      if (current.length > 0) clearNewsBlur();
+      return;
     }
-    if (!node.classList.contains(BLUR_CLASS)) node.classList.add(BLUR_CLASS);
-    if (node.getAttribute(NEWS_MARKER) !== "1") node.setAttribute(NEWS_MARKER, "1");
+
+    const targetSet = new Set(targets);
+    current.forEach((node) => {
+      if (!targetSet.has(node)) {
+        node.classList.remove(BLUR_CLASS);
+        node.removeAttribute(NEWS_MARKER);
+      }
+    });
+
+    targets.forEach((node) => {
+      if (!node.classList.contains(BLUR_CLASS)) node.classList.add(BLUR_CLASS);
+      if (node.getAttribute(NEWS_MARKER) !== "1") node.setAttribute(NEWS_MARKER, "1");
+    });
   };
 
   const clearBadges = () => {
@@ -242,6 +267,3 @@
     start();
   }
 })();
-//
-// This section of code for blurring linkedIn news section helped with cursor + removing badge notifications
-

--- a/focus_bear/src/linkedin/linkedin.ts
+++ b/focus_bear/src/linkedin/linkedin.ts
@@ -1,167 +1,247 @@
 (() => {
-  console.log("LinkedIn blur script injected at", location.href);
+  const STYLE_ID = "focusbear-linkedin-style";
+  const BLUR_CLASS = "focusbear-linkedin-news-blur";
+  const HIDE_BADGE_CLASS = "focusbear-hide-badge";
+  const NEWS_MARKER = "data-focusbear-news-blur";
+  const BADGE_MARKER = "data-focusbear-badge-hidden";
 
-  const BlurSection =
-    "filter:blur(8px)!important; pointer-events:none!important; user-select:none!important;";
+  const injectStyles = () => {
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement("style");
+    el.id = STYLE_ID;
+    el.textContent = `
+      .${BLUR_CLASS} {
+        filter: blur(8px) !important;
+        pointer-events: none !important;
+        user-select: none !important;
+        transition: filter 120ms linear !important;
+      }
+      .${HIDE_BADGE_CLASS} {
+        display: none !important;
+      }
+    `;
+    document.head.appendChild(el);
+  };
 
-  // Blur "people you may know" toggle function
-  const togglePYMK = (on: boolean) => {
-    document.querySelectorAll<HTMLElement>("section").forEach((sec) => {
-      if (
-        /people you may know/i.test(sec.innerText) ||
-        /People to follow based on your activity/i.test(sec.innerText) ||
-        /People who are in/i.test(sec.innerText) ||
-        /People in the/i.test(sec.innerText) ||
-        /More suggestions for you/i.test(sec.innerText)
-      ) {
-        sec.style.cssText = on ? BlurSection : "";
+  const isHomeFeed = () => window.location.pathname.startsWith("/feed");
+
+  const isLikelyNewsCard = (el: HTMLElement) => {
+    const rect = el.getBoundingClientRect();
+    const rightSide = rect.left > window.innerWidth * 0.5;
+    const cardLikeSize =
+      rect.width >= 220 && rect.width <= 450 && rect.height >= 180 && rect.height <= 1200;
+    return rightSide && cardLikeSize;
+  };
+
+  /** Find only the LinkedIn News card in the right rail (not the whole page/sidebar). */
+  const findNewsContainer = (): HTMLElement | null => {
+    if (!isHomeFeed()) return null;
+
+    // Text-first targeting: find nodes whose own textContent contains "LinkedIn News".
+    const baseNodes = Array.from(
+      document.querySelectorAll<HTMLElement>("div, section, aside"),
+    ).filter((el) => (el.textContent || "").includes("LinkedIn News"));
+    if (baseNodes.length === 0) return null;
+
+    const candidates: HTMLElement[] = [];
+    baseNodes.forEach((node) => {
+      // Walk up to a card-like ancestor and keep the first good match.
+      let current: HTMLElement | null = node;
+      for (let i = 0; i < 6 && current; i += 1) {
+        const text = (current.textContent || "").toLowerCase();
+        if (
+          isLikelyNewsCard(current) &&
+          (text.includes("top stories") ||
+            text.includes("show more news") ||
+            text.includes("today's puzzles"))
+        ) {
+          candidates.push(current);
+          break;
+        }
+        current = current.parentElement;
       }
     });
+
+    if (candidates.length === 0) return null;
+    return candidates.sort(
+      (a, b) => a.clientWidth * a.clientHeight - b.clientWidth * b.clientHeight,
+    )[0];
   };
 
-  // Blur LinkedIn News toggle function
-  const toggleNews = (on: boolean) => {
-    // "LinkedIn News" widget typically appears as a <section> containing that heading
-    document.querySelectorAll<HTMLElement>("section").forEach((sec) => {
-      // Look for "LinkedIn News" or "Top stories" in the section's innerText
-      if (/LinkedIn News/i.test(sec.innerText) || /Top stories/i.test(sec.innerText)) {
-        sec.style.cssText = on ? BlurSection : "";
-      }
-
-      // Also Look for Notifications feed
-      if (location.pathname.startsWith("/notifications")) {
-        document
-          .querySelectorAll<HTMLElement>("div.scaffold-finite-scroll__content")
-          .forEach((el) => {
-            el.style.cssText = on ? BlurSection : "";
-          });
-      }
+  const clearNewsBlur = () => {
+    document.querySelectorAll<HTMLElement>(`[${NEWS_MARKER}="1"]`).forEach((el) => {
+      el.classList.remove(BLUR_CLASS);
+      el.removeAttribute(NEWS_MARKER);
     });
   };
 
-  // Blur job suggestions toggle function
-  const toggleJobPageSections = (on: boolean) => {
-    // Blur any sections by their visible heading text
-    document.querySelectorAll<HTMLElement>("section").forEach((sec) => {
-      if (
-        /Top job picks for you/i.test(sec.innerText) ||
-        /Suggested job searches/i.test(sec.innerText) ||
-        /Hiring in your network/i.test(sec.innerText) ||
-        /More jobs for you/i.test(sec.innerText) ||
-        /Recommended for you/i.test(sec.innerText)
-      ) {
-        sec.style.cssText = on ? BlurSection : "";
-      }
-    });
-
-    // Blur structural modules by class or ID
-    [
-      "div.discovery-templates-jobs-feed-discovery-module",
-      "div.discovery-templates-jobs-feed-discovery-module__next-page",
-      "section.discovery-templates-vertical-list__next-page",
-      "ul#jobs-home-vertical-list__entity-list",
-    ].forEach((selector) => {
-      document.querySelectorAll<HTMLElement>(selector).forEach((el) => {
-        el.style.cssText = on ? BlurSection : "";
-      });
-    });
-  };
-
-  // Blur home feed
-  const toggleHomeFeed = (on: boolean) => {
-    document
-      .querySelectorAll<HTMLElement>(".scaffold-finite-scroll__content .feed-shared-update-v2")
-      .forEach((sec) => {
-        sec.style.cssText = on ? BlurSection : "";
-      });
-  };
-
-  // Hide red notification badge
-  const toggleNotificationBadge = (on: boolean) => {
-    const badges = document.querySelectorAll<HTMLElement>(
-      ".global-nav__primary-link-notification-badge, .notification-badge",
-    );
-
-    badges.forEach((badge) => {
-      badge.style.cssText = on ? "display: none;" : "";
-    });
-  };
-
-  // Stored setting on load
-  chrome.storage.local.get(
-    {
-      linkedinBlurPYMK: true,
-      linkedinBlurNews: true,
-      linkedinBlurJobs: true,
-      linkedinBlurHome: true,
-      linkedinRemoveBadges: true,
-    },
-    ({
-      linkedinBlurPYMK,
-      linkedinBlurNews,
-      linkedinBlurJobs,
-      linkedinBlurHome,
-      linkedinRemoveBadges,
-    }) => {
-      togglePYMK(linkedinBlurPYMK);
-      toggleNews(linkedinBlurNews);
-      toggleJobPageSections(linkedinBlurJobs);
-      toggleHomeFeed(linkedinBlurHome);
-      toggleNotificationBadge(linkedinRemoveBadges);
-    },
-  );
-
-  // Re-apply if LinkedIn lazy-injects more sections
-  new MutationObserver((muts) => {
-    if (muts.some((m) => m.addedNodes.length)) {
-      chrome.storage.local.get(
-        {
-          linkedinBlurPYMK: true,
-          linkedinBlurNews: true,
-          linkedinBlurJobs: true,
-          linkedinBlurHome: true,
-          linkedinRemoveBadges: true,
-        },
-        ({
-          linkedinBlurPYMK,
-          linkedinBlurNews,
-          linkedinBlurJobs,
-          linkedinBlurHome,
-          linkedinRemoveBadges,
-        }) => {
-          togglePYMK(linkedinBlurPYMK);
-          toggleNews(linkedinBlurNews);
-          toggleJobPageSections(linkedinBlurJobs);
-          toggleHomeFeed(linkedinBlurHome);
-          toggleNotificationBadge(linkedinRemoveBadges);
-        },
-      );
+  const setBlurNews = (enabled: boolean) => {
+    const current = document.querySelector<HTMLElement>(`[${NEWS_MARKER}="1"]`);
+    if (!enabled) {
+      if (current) clearNewsBlur();
+      return;
     }
-  }).observe(document.body, { childList: true, subtree: true });
 
-  // Listen for popup's toggle
+    const node = findNewsContainer();
+    if (!node) return;
+
+    // Keep blur stable: only switch DOM state if target changed.
+    if (current && current !== node) {
+      current.classList.remove(BLUR_CLASS);
+      current.removeAttribute(NEWS_MARKER);
+    }
+    if (!node.classList.contains(BLUR_CLASS)) node.classList.add(BLUR_CLASS);
+    if (node.getAttribute(NEWS_MARKER) !== "1") node.setAttribute(NEWS_MARKER, "1");
+  };
+
+  const clearBadges = () => {
+    document.querySelectorAll<HTMLElement>(`[${BADGE_MARKER}="1"]`).forEach((el) => {
+      el.classList.remove(HIDE_BADGE_CLASS);
+      el.removeAttribute(BADGE_MARKER);
+    });
+  };
+
+  /** Hide count bubbles on top nav links; keep icons visible (matches "Remove Badges"). */
+  const setRemoveBadges = (enabled: boolean) => {
+    clearBadges();
+    if (!enabled) return;
+
+    const seen = new Set<HTMLElement>();
+    const navItemLabels = ["my network", "jobs", "messaging", "notifications"];
+
+    const navCandidates = Array.from(
+      document.querySelectorAll<HTMLElement>("a[aria-label], button[aria-label]"),
+    ).filter((el) => {
+      const label = (el.getAttribute("aria-label") || "").toLowerCase();
+      return navItemLabels.some((prefix) => label.startsWith(prefix));
+    });
+
+    const isBadgeBubble = (el: HTMLElement) => {
+      const text = (el.textContent || "").trim();
+      if (!/^\d+$/.test(text)) return false;
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      // Keep this strict so we never hide icons/containers.
+      if (rect.width > 42 || rect.height > 32) return false;
+      if (el.childElementCount > 1) return false;
+      return true;
+    };
+
+    const collectBadgeCandidates = (root: HTMLElement) => {
+      const selectors = [
+        "[aria-label*='unread' i]",
+        "[data-test-notification-badge]",
+        ".notification-badge",
+        ".global-nav__primary-link-notif-badge",
+        ".global-nav__primary-link-notification-badge",
+        "span",
+        "div",
+      ];
+      selectors.forEach((selector) => {
+        root.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+          if (isBadgeBubble(el)) seen.add(el);
+        });
+      });
+    };
+
+    navCandidates.forEach((item) => {
+      collectBadgeCandidates(item);
+      // Search one level up for the tiny badge that may be sibling of icon span.
+      const itemContainer = item.closest<HTMLElement>("li, nav");
+      if (itemContainer) collectBadgeCandidates(itemContainer);
+    });
+
+    seen.forEach((node) => {
+      node.classList.add(HIDE_BADGE_CLASS);
+      node.setAttribute(BADGE_MARKER, "1");
+    });
+  };
+
+  const applyFromStorage = (done?: () => void) => {
+    injectStyles();
+    chrome.storage.local.get({ linkedinBlurNews: true, linkedinRemoveBadges: true }, (res) => {
+      try {
+        setBlurNews(!!res.linkedinBlurNews);
+        setRemoveBadges(!!res.linkedinRemoveBadges);
+      } catch (e) {
+        console.warn("FocusBear: LinkedIn apply failed", e);
+      } finally {
+        done?.();
+      }
+    });
+  };
+
   chrome.runtime.onMessage.addListener((msg, _s, sendResponse) => {
-    if (msg.type === "TOGGLE_LINKEDIN_BLUR") {
-      togglePYMK(!!msg.payload);
-      sendResponse({ ok: true });
-    }
+    if (!msg?.type) return;
     if (msg.type === "TOGGLE_LINKEDIN_NEWS") {
-      toggleNews(!!msg.payload);
+      setBlurNews(!!msg.payload);
       sendResponse({ ok: true });
-    }
-    if (msg.type === "TOGGLE_LINKEDIN_JOBS_BLUR") {
-      toggleJobPageSections(!!msg.payload);
-      sendResponse({ ok: true });
-    }
-    if (msg.type === "TOGGLE_LINKEDIN_HOME") {
-      console.log("Received TOGGLE_LINKEDIN_HOME message:", msg.payload);
-      toggleHomeFeed(!!msg.payload);
-      sendResponse({ ok: true });
+      return;
     }
     if (msg.type === "TOGGLE_LINKEDIN_BADGES") {
-      console.log("Received TOGGLE_LINKEDIN_BADGES message:", msg.payload);
-      toggleNotificationBadge(!!msg.payload);
+      setRemoveBadges(!!msg.payload);
       sendResponse({ ok: true });
+      return;
     }
   });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "local") return;
+    if (changes.linkedinBlurNews || changes.linkedinRemoveBadges) scheduleApply();
+  });
+
+  let scheduled = false;
+  let scheduleTimer: number | null = null;
+  const scheduleApply = () => {
+    if (scheduled) return;
+    scheduled = true;
+    if (scheduleTimer) window.clearTimeout(scheduleTimer);
+    scheduleTimer = window.setTimeout(
+      () =>
+        applyFromStorage(() => {
+          scheduled = false;
+          scheduleTimer = null;
+        }),
+      150,
+    );
+  };
+
+  const patchHistory = () => {
+    type M = typeof history.pushState;
+    const wrap = (orig: M) =>
+      function (this: History, ...args: Parameters<M>): ReturnType<M> {
+        const ret = orig.apply(this, args);
+        window.dispatchEvent(new Event("focusbear-linkedin-route"));
+        return ret;
+      };
+    try {
+      history.pushState = wrap(history.pushState);
+      history.replaceState = wrap(history.replaceState);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const start = () => {
+    applyFromStorage(() => {
+      scheduled = false;
+    });
+    if (document.body) {
+      new MutationObserver((muts) => {
+        if (muts.some((m) => m.addedNodes.length > 0)) scheduleApply();
+      }).observe(document.body, { childList: true, subtree: true });
+    }
+    patchHistory();
+    window.addEventListener("focusbear-linkedin-route", scheduleApply);
+    window.addEventListener("popstate", scheduleApply);
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
 })();
+//
+// This section of code for blurring linkedIn news section helped with cursor + removing badge notifications
+

--- a/focus_bear/src/popup.tsx
+++ b/focus_bear/src/popup.tsx
@@ -551,38 +551,31 @@ const App = () => {
     }
   };
 
-  const handleLinkedinNewsToggle = async () => {
-    const newValue = !linkedinBlurNews;
-    setLinkedinBlurNews(newValue);
-    await chrome.storage.local.set({ linkedinBlurNews: newValue });
-
+  const sendLinkedinToggleToActiveTab = async (type: string, payload: boolean) => {
     const [tab] = await chrome.tabs.query({
       active: true,
       currentWindow: true,
     });
-    if (tab?.id) {
-      await chrome.tabs.sendMessage(tab.id, {
-        type: "TOGGLE_LINKEDIN_NEWS",
-        payload: newValue,
-      });
+    if (!tab?.id || !tab.url?.includes("linkedin.com")) return;
+    try {
+      await chrome.tabs.sendMessage(tab.id, { type, payload });
+    } catch {
+      // Content script may not be ready yet; storage listener in linkedin.ts will still apply.
     }
+  };
+
+  const handleLinkedinNewsToggle = async () => {
+    const newValue = !linkedinBlurNews;
+    setLinkedinBlurNews(newValue);
+    await chrome.storage.local.set({ linkedinBlurNews: newValue });
+    await sendLinkedinToggleToActiveTab("TOGGLE_LINKEDIN_NEWS", newValue);
   };
 
   const handleLinkedinBadgeToggle = async () => {
     const newValue = !linkedinRemoveBadges;
     setLinkedinRemoveBadges(newValue);
     await chrome.storage.local.set({ linkedinRemoveBadges: newValue });
-
-    const [tab] = await chrome.tabs.query({
-      active: true,
-      currentWindow: true,
-    });
-    if (tab?.id) {
-      await chrome.tabs.sendMessage(tab.id, {
-        type: "TOGGLE_LINKEDIN_BADGES",
-        payload: newValue,
-      });
-    }
+    await sendLinkedinToggleToActiveTab("TOGGLE_LINKEDIN_BADGES", newValue);
   };
 
   const handleWikipediaLinkPopupToggle = async () => {
@@ -826,7 +819,7 @@ const App = () => {
           <Toggle checked={false} onChange={() => {}} disabled />
         </label>
         <label className="option-label">
-          <span className="option-text">Remove Notifications</span>
+          <span className="option-text">{t("remove_badges")}</span>
           <Toggle checked={linkedinRemoveBadges} onChange={handleLinkedinBadgeToggle} />
         </label>
         <label className="option-label">


### PR DESCRIPTION
now hides the notification badge on the top bar of linkedIn and the news/Todays puzzle section with the toggle

<img width="1470" height="812" alt="image" src="https://github.com/user-attachments/assets/6655d54a-21e8-468d-b7d6-8aade43bee0c" />
