### PR TITLE
US89 | Add Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,215 +1,213 @@
-# P000395SE Completion of Focus Bear Chrome Extension
+# P000395SE Focus Bear Chrome Extension
 
-**Focus Bear** is a Chrome extension designed to help users minimise distractions and stay focused by blocking access to distracting websites. After the completion of a focus session a break timer runs. You can also add website URL's to a block list to limit ditractions and can toggle off distracting popup's in popular websites like LinkedIn and Youtube to blur the news feed section for example. 
+**Focus Bear** is a Chrome extension (Manifest V3) that helps users stay focused by blocking distracting websites, running Pomodoro-style focus sessions, and reducing visual noise on sites like YouTube, LinkedIn, Gmail, Reddit, and Wikipedia.
+
+**Focus Bear** is a Chrome extension designed to help users minimise distractions and stay focused by blocking access to distracting websites. After the completion of a focus session a break timer runs. You can also add website URL's to a block list to limit ditractions and can toggle off distracting popup's in popular websites like LinkedIn and Youtube to blur the news feed section for example.
+
+Built as a capstone project extending the [Focus Bear](https://www.focusbear.io/) productivity app ecosystem.
 
 ## GitHub URL
 
 <https://github.com/Focus-Bear/chrome_extension>
 
-## Deloyment URL
+---
 
-- Not deployed yet
+## Extension Overview
+
+### Focus Sessions
+
+- Start a Pomodoro-style timer with a configurable work duration and break duration
+- Set durations via a draggable circular slider or preset values (5, 10, 30 min)
+- Pause, resume, and reset an active session
+- Break timer starts automatically after the work phase ends
+- Desktop notifications fire when each phase completes
+- Settings are locked and inaccessible while a focus session is active
+
+### Blocklist
+
+- Add and remove websites from a personal blocklist
+- During an active focus session, any matching site is immediately redirected to a blocked page
+- Blocking applies to all open tabs, not just newly opened ones
+- Blocked domains are listed in the popup for quick reference
+- Active hours can be configured to limit when blocking is enforced
+
+### Unfocus / Intention Popup
+
+- A floating popup appears on YouTube and LinkedIn before the page loads
+- Captures the user's intention and how long they plan to spend
+- Sessions under 10 minutes require 5+ characters of reasoning; 10+ minute sessions require 15+
+- Scrollable session cards in the popup show any currently active unfocus timers
+
+### Distraction Blurring
+
+Each toggle is saved globally and persists across tabs and reloads.
+
+| Site            | What can be blurred or hidden                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **YouTube**     | Homepage recommendations, chips bar, Shorts, comments, You menu                                                   |
+| **LinkedIn**    | Homepage feed, notifications, trending news, job recommendations, connection recommendations, notification badges |
+| **Gmail**       | Inbox, Promotions tab, Social and Updates tabs                                                                    |
+| **Wikipedia**   | Main page content; link preview popups on hover                                                                   |
+| **Reddit**      | Distracting feed content (via content script)                                                                     |
+| **X / Twitter** | Distracting feed content (via content script)                                                                     |
+
+### General
+
+- Spanish language support (mirrors Chrome's language setting)
+- UI follows Focus Bear branding and colour scheme
+- All settings persist via `chrome.storage.local`
+
+### Known Limitations
+
+- Distraction blurring on Gmail and some LinkedIn pages can be inconsistent depending on page load timing
+- LinkedIn toggles can affect YouTube subscription blurring due to shared content script logic
+
+---
 
 ## Technologies
 
-- **React 19** with **TypeScript** 
-- **HTML / CSS**
-- **Vite 6** (build and dev server)
-- **Chrome Extension Manifest V3** 
-- **Radix UI Themes** and **Lucide React** 
-- **Oxlint** and **Oxfmt** 
+| Tool                           | Purpose                        |
+| ------------------------------ | ------------------------------ |
+| React 19 + TypeScript          | UI components and popup logic  |
+| Vite 6                         | Build tooling and dev server   |
+| Chrome Extension Manifest V3   | Extension platform             |
+| Radix UI Themes + Lucide React | UI component library and icons |
+| Oxlint                         | Linting                        |
+| Oxfmt                          | Code formatting                |
+| Vitest                         | Unit testing                   |
 
-## Changelog
+---
 
-### Version 1.0.0 • 15 June 2025
+## Testing
 
-#### 🚀 New Features
+Unit tests cover the core business logic in `src/lib/` — the pure functions that have no Chrome API dependency.
 
-- A floating popup, to capture users intention and time allocation on YouTube and LinkedIn
-- A popup to view active focus sessions and a settings page to toggle blur features
-- Spanish language support that mirrors Chrome's language settings
+```bash
+cd focus_bear
+npm test
+```
 
-- Toggle to blur YouTube homepage recommendations and chips bar
-- Toggle to blur YouTube shorts
-- Toggle to blur YouTube comments
+**What is tested (38 tests across 3 files):**
 
-- Toggle to blur LinkedIn homepage feed
-- Toggle to blur LinkedIn notifications and trending news
-- Toggle to blur LinkedIn job recommendations
-- Toggle to blur LinkedIn connection recommendations
+| File                | Functions covered                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `focus.test.ts`     | `isFocusActive`, `buildFocusSessionState`, `computeTimeLeft`, `buildResumedSessionState`, pause→resume round trip |
+| `blocklist.test.ts` | `urlIsBlocklisted`, `buildBlockedUrl`                                                                             |
+| `unfocus.test.ts`   | `computeUnfocusEndTime`, `isUnfocusSessionActive`                                                                 |
 
-#### 🛠 Improvements
+Chrome API wiring (alarms, storage, message handlers) is not unit tested — that would require a Chrome API mock layer and is out of scope for this project.
 
-- Styling follows Focus Bear branding and colour scheme
-- Settings are global and saved across different tabs
-- Settings are saved on page reload
-- If there is an active focus session, settings page cannot be accessed
-- If a focus session is expected to be 10+ mins, 15+ characters of reasoning is required, other than 5 chracters
-- Active session cards in popup are scrollable
+---
 
-#### 🐞 Bug Fixes
+## CI Pipeline
 
-- Shorts section on YouTube homepage not blurred despite toggle being enabled in FocusBear extension
-- Subscription section on YouTube homepage not blurred despite toggle being enabled in FocusBear extension
-- Home Page blur not working after navigating from Shorts or Subscriptions page and refreshing
+Every pull request to `main` triggers three parallel jobs defined in `.github/workflows/lint.yml`:
 
-#### ❗ Known Issues
+| Job      | Tool   | What it checks              |
+| -------- | ------ | --------------------------- |
+| `oxlint` | Oxlint | Code quality and lint rules |
+| `oxfmt`  | Oxfmt  | Consistent code formatting  |
+| `test`   | Vitest | All unit tests pass         |
 
-- LinkedIn toggles also affects YouTube subscription blurring
-- Intention popup css being injected improperly on all LinkedIn pages
+All three must pass before a PR can be merged.
 
-### Version 1.1.0 • 2 Nov 2025
-
-#### 🚀 New Features
-
-- Pomodoro Timer added to popup from original extension
-
-- Toggle to blur YouTube you menu
-
-- Toggle to remove LinkedIn notification badges
-
-- Toggle to add Wikipedia link popups
-- Toggle to blur Wikipedia main page
-
-- Toggle to blur Gmail
-- Toggle to blur Gmail promotions
-- Toggle to blur Gmail social and updates
-
-- Blocklist accessible through settings
-- Site entry text box trims urls and adds to blocklist
-- Blocked domains displayed in popup
-- Blocked domains are blurred in active hours
-- Remove option for each domain in list
-- Options to set and save active hours for blocklist
-- Popup when attempting to access blocked domains
-
-#### 🛠 Improvements
-
-- Various new themed messages added to intention popup
-
-### Version 1.2.0 • 4th April 2026
-
-#### 🚀 New Features
-
-- Settings button now on top heading bar
-- Can now drag the focus session length and break tie you want or select pre determined time values like 5, 10, 30 min sessions and breaks 
-
-#### 🛠 Improvements
-
-- Refresh of UI: styling, colours, alignment, layout
-- Removal of relaxed list section
-- Using accordian to hide distract toggles
-- High contrast background and text for readability
-
-#### 🐞 Bug Fixes
-
-- Blurring of distracting websites completly not working before but now it's mostly working in LinkedIn, Youtube and Reddit
-- Fixed intention popup displaying different UI based on website like LinkedIn or Youtube
-
-#### ❗ Known Issues
-
-- Distraction blurring on certain websites still a bit inconsistent or not implemented e.g. Gmail
-- More UI and functional tests could be added to ensure it's working as expected
+---
 
 ## Getting Started
 
-These instructions will help you get a local copy of the project up and running for development/testing.
+### Prerequisites
 
-**Clone the repository**: git clone <https://github.com/Focus-Bear/chrome_extension>
+- Node.js 24+
+- Chrome (or any Chromium-based browser)
 
-### How to run
+### Install and build
 
-1. Navigate to directory (after cloning, from the repo root)
-   - cd focus_bear
+```bash
+# From repo root
+cd focus_bear
+npm install
+npm run build
+```
 
-2. Install dependencies
-   - npm install
+### Load in Chrome
 
-3. Build the extension (generates a `dist/` folder)
-   - npm run build
+1. Open `chrome://extensions/`
+2. Enable **Developer mode**
+3. Click **Load unpacked**
+4. Select the `focus_bear/dist` folder
 
-4. Load the extension in Chrome
-   - Open Chrome and go to chrome://extensions/
-   - Turn on **Developer mode**
-   - Click **Load unpacked**
-   - Select the `focus_bear/dist` folder (not `src/` or the repo root)
+After any code changes: run `npm run build` again, then click **Reload** on the extension card and refresh any tabs you're testing.
 
-5. After code changes, click **Reload** on the extension card and refresh any tabs you’re testing
+### Other commands
 
-### Formatting
-
-1. Navigate to directory
-   - cd focus_bear
-
-2. Install dependencies (if you haven’t already)
-   - npm install
-
-3. Run Oxfmt
-   - npm run fmt
-
-### Linting
-
-To lint the project using Oxlint:
-
-1. Navigate to directory
-   - cd focus_bear
-
-2. Install dependencies (if you haven’t already)
-   - npm install
-
-3. Run Oxlint
-   - npm run lint
+```bash
+npm run fmt        # Format code with Oxfmt
+npm run fmt:check  # Check formatting (used in CI)
+npm run lint       # Lint with Oxlint
+npm test           # Run unit tests
+```
 
 ### Troubleshooting
 
-If you’re running into issues like missing build files or unexpected behaviour, try the following:
+- Confirm `dist/` exists and contains a `manifest.json`
+- Make sure you loaded `focus_bear/dist`, not the repo root or `src/`
+- Developer mode must be on in Chrome
+- If behaviour is unexpected after changes, do a clean rebuild:
 
-- Check that `dist/` exists and has a `manifest.json` inside it
-- You loaded **`focus_bear/dist`** in chrome://extensions/ (not the whole repo)
-- Developer mode is on
-- You ran `npm run build` from inside `focus_bear`
-- If it still acts weird, from `focus_bear` try:
-  1. rm -rf dist
-  2. npm run build
-  3. Reload the extension in Chrome
+```bash
+rm -rf dist
+npm run build
+```
+
+Then reload the extension in Chrome.
+
+---
 
 ## Project Structure
 
 ```text
 chrome_extension/               # Git repo root (this README lives here)
-└── focus_bear/                 # Extension app — run npm commands here
+└── focus_bear/                 # Extension source — run npm commands from here
     ├── public/
     │   ├── _locales/           # en, es language strings
     │   ├── icons/
     │   ├── fonts/
     │   ├── manifest.json
-    │   ├── blocked.html        # Page shown when blocklist blocks a site
+    │   ├── blocked.html        # Page shown when a blocked site is accessed
     │   └── blocked.js
     │
     ├── src/
-    │   ├── components/         # Focus timer UI (FocusTimer.tsx, etc.)
-    │   ├── context/            # Intention popup / unfocus helpers
-    │   ├── styles/             # popup.css, intentionPopup.css, etc.
+    │   ├── components/         # Reusable UI (FocusTimer, CircularSlider, etc.)
+    │   ├── context/            # Intention popup context and unfocus timer helpers
+    │   ├── styles/
+    │   ├── lib/                # Pure business logic (no Chrome API deps)
+    │   │   ├── focus.ts        # Session state helpers
+    │   │   ├── blocklist.ts    # URL matching and redirect URL builders
+    │   │   ├── unfocus.ts      # Unfocus session timing
+    │   │   └── __tests__/      # Vitest unit tests
     │   ├── youtube/
     │   ├── linkedin/
     │   ├── gmail/
     │   ├── wikipedia/
     │   ├── reddit/
-    │   ├── background.ts       # Service worker (focus sessions, blocklist, alarms)
-    │   ├── blocklist.ts
+    │   ├── x/
+    │   ├── background.ts       # Service worker — sessions, alarms, blocklist enforcement
+    │   ├── blocklist.ts        # Content script — per-page blocklist check
     │   ├── content.ts          # Injects unfocus intention popup on supported sites
     │   ├── popup.html
     │   ├── popup.tsx           # Main extension popup
-    │   └── intentionPopup.tsx  # Floating unfocus popup (built as floatingPopup.js)
+    │   └── intentionPopup.tsx  # Floating unfocus popup
     │
-    ├── package.json
-    ├── package-lock.json
+    ├── vitest.config.ts
+    ├── vite.config.ts
     ├── tsconfig.json
+    ├── package.json
     ├── .oxfmtrc.json
-    ├── .oxlintrc.json
-    └── vite.config.ts
+    └── .oxlintrc.json
 ```
+
+---
 
 ## License
 
-- N/A
+N/A

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # P000395SE Focus Bear Chrome Extension
 
-**Focus Bear** is a Chrome extension (Manifest V3) that helps users stay focused by blocking distracting websites, running Pomodoro-style focus sessions, and reducing visual noise on sites like YouTube, LinkedIn, Gmail, Reddit, and Wikipedia.
-
-**Focus Bear** is a Chrome extension designed to help users minimise distractions and stay focused by blocking access to distracting websites. After the completion of a focus session a break timer runs. You can also add website URL's to a block list to limit ditractions and can toggle off distracting popup's in popular websites like LinkedIn and Youtube to blur the news feed section for example.
+**Focus Bear** is a Chrome extension (Manifest V3) that helps users stay focused by blocking distracting websites, running Pomodoro-style focus sessions, website blocking, and reducing visual noise on sites like YouTube, LinkedIn, Gmail, Reddit, and Wikipedia.
 
 Built as a capstone project extending the [Focus Bear](https://www.focusbear.io/) productivity app ecosystem.
 

--- a/focus_bear/package-lock.json
+++ b/focus_bear/package-lock.json
@@ -33,7 +33,8 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.24.1",
         "vite": "^6.2.0",
-        "vite-plugin-static-copy": "^3.0.0"
+        "vite-plugin-static-copy": "^3.0.0",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -81,6 +82,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1060,9 +1062,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -3571,6 +3573,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3616,6 +3625,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.0.313",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.313.tgz",
@@ -3626,6 +3646,13 @@
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -3671,6 +3698,7 @@
       "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.13.0"
       }
@@ -3681,6 +3709,7 @@
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3691,6 +3720,7 @@
       "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3741,6 +3771,7 @@
       "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.29.0",
         "@typescript-eslint/types": "8.29.0",
@@ -3944,12 +3975,126 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4019,6 +4164,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4070,6 +4225,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -4113,6 +4269,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4242,6 +4408,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
@@ -4312,6 +4485,7 @@
       "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4474,6 +4648,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4482,6 +4666,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4963,6 +5157,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5048,6 +5252,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -5229,6 +5444,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5413,6 +5635,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5422,6 +5645,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5669,6 +5893,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5678,6 +5909,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -5705,15 +5950,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5723,11 +5985,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5738,11 +6003,12 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5758,6 +6024,16 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5811,6 +6087,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5958,6 +6235,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6169,6 +6447,110 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6199,6 +6581,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/focus_bear/package.json
+++ b/focus_bear/package.json
@@ -12,7 +12,8 @@
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
     "lint": "oxlint",
-    "lint:fix": "oxlint --fix"
+    "lint:fix": "oxlint --fix",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-tabs": "^1.1.13",
@@ -40,6 +41,7 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0",
-    "vite-plugin-static-copy": "^3.0.0"
+    "vite-plugin-static-copy": "^3.0.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/focus_bear/public/manifest.json
+++ b/focus_bear/public/manifest.json
@@ -20,7 +20,8 @@
     }
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/focus_bear/public/manifest.json
+++ b/focus_bear/public/manifest.json
@@ -58,13 +58,12 @@
       "js": ["content.js", "reddit.js"],
       "css": ["assets/intentionPopup.css"]
     },
-    
+
     {
-     "matches": ["*://*.x.com/*"],
+      "matches": ["*://*.x.com/*"],
       "js": ["content.js", "x.js"],
       "css": ["assets/intentionPopup.css"]
     }
-
   ],
   "web_accessible_resources": [
     {

--- a/focus_bear/src/background.ts
+++ b/focus_bear/src/background.ts
@@ -1,3 +1,6 @@
+import { isFocusActive, buildFocusSessionState, computeTimeLeft, buildResumedSessionState } from "./lib/focus.js";
+import { urlIsBlocklisted, buildBlockedUrl } from "./lib/blocklist.js";
+
 // Fires on a real install or version-upgrade. (only when you first load or bump the version field in manifest.json)
 chrome.runtime.onInstalled.addListener((details) => {
   console.log("onInstalled:", details.reason);
@@ -137,20 +140,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "startFocusSession") {
     const { workDuration, breakDuration, onBreak, task } = request;
 
-    const startTime = Date.now();
-    const duration = onBreak ? breakDuration : workDuration;
-    const endTime = startTime + duration * 1000;
-
-    const focusSessionState = {
-      task: task || "",
-      workDuration,
-      breakDuration,
-      startTime,
-      endTime,
-      isRunning: true,
-      onBreak,
-      started: true,
-    };
+    const focusSessionState = buildFocusSessionState({ workDuration, breakDuration, onBreak, task });
+    const { endTime } = focusSessionState;
 
     // Clear any previous focus alarms before starting fresh
     chrome.alarms.clear(ALARM_FOCUS_WORK);
@@ -169,8 +160,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     chrome.storage.local.get("focusSessionState", (data) => {
       const state = data.focusSessionState;
       if (state) {
-        const remaining = Math.max(Math.floor((state.endTime - Date.now()) / 1000), 0);
-        const updated = { ...state, isRunning: false, timeLeft: remaining };
+        const updated = { ...state, isRunning: false, timeLeft: computeTimeLeft(state) };
         chrome.storage.local.set({ focusSessionState: updated });
         // Cancel alarms while paused, re-created on resume
         chrome.alarms.clear(ALARM_FOCUS_WORK);
@@ -185,9 +175,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     chrome.storage.local.get("focusSessionState", (data) => {
       const prev = data.focusSessionState;
       if (prev && !prev.isRunning && prev.timeLeft) {
-        const startTime = Date.now();
-        const endTime = startTime + prev.timeLeft * 1000;
-        const focusSessionState = { ...prev, startTime, endTime, isRunning: true };
+        const focusSessionState = buildResumedSessionState(prev);
+        const { endTime } = focusSessionState;
         chrome.storage.local.set({ focusSessionState }, () => {
           const alarmName = prev.onBreak ? ALARM_FOCUS_BREAK : ALARM_FOCUS_WORK;
           chrome.alarms.create(alarmName, { when: endTime });
@@ -219,35 +208,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Hard redirect any url that matches blocklisted string while in a Focus Session
 // Redirects to blocked.html
 
-type FocusState = { started?: boolean; onBreak?: boolean } | undefined;
-
 const BLOCKED_PAGE = chrome.runtime.getURL("blocked.html");
-
-function isFocusActive(state: FocusState): boolean {
-  return !!(state && state.started === true && state.onBreak !== true);
-}
-
-function urlIsBlocklisted(
-  url: string,
-  blocklist: string[] | undefined,
-): { blocked: boolean; host: string } {
-  if (!blocklist || blocklist.length === 0) return { blocked: false, host: "" };
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return { blocked: false, host: parsed.hostname };
-    }
-    const host = parsed.hostname;
-    const blocked = blocklist.some((site) => site && host.includes(site));
-    return { blocked, host };
-  } catch {
-    return { blocked: false, host: "" };
-  }
-}
-
-function buildBlockedUrl(host: string): string {
-  return BLOCKED_PAGE + "?d=" + encodeURIComponent(host);
-}
 
 function maybeBlockTab(tabId: number, url: string | undefined) {
   if (!url) return;
@@ -259,7 +220,7 @@ function maybeBlockTab(tabId: number, url: string | undefined) {
       if (!isFocusActive(focusSessionState)) return;
       const { blocked, host } = urlIsBlocklisted(url, blocklist);
       if (!blocked) return;
-      chrome.tabs.update(tabId, { url: buildBlockedUrl(host) }).catch((err) => {
+      chrome.tabs.update(tabId, { url: buildBlockedUrl(BLOCKED_PAGE, host) }).catch((err) => {
         console.warn("[FocusBear] failed to redirect blocked tab:", err);
       });
     },

--- a/focus_bear/src/background.ts
+++ b/focus_bear/src/background.ts
@@ -1,4 +1,9 @@
-import { isFocusActive, buildFocusSessionState, computeTimeLeft, buildResumedSessionState } from "./lib/focus.js";
+import {
+  isFocusActive,
+  buildFocusSessionState,
+  computeTimeLeft,
+  buildResumedSessionState,
+} from "./lib/focus.js";
 import { urlIsBlocklisted, buildBlockedUrl } from "./lib/blocklist.js";
 
 // Fires on a real install or version-upgrade. (only when you first load or bump the version field in manifest.json)
@@ -140,7 +145,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "startFocusSession") {
     const { workDuration, breakDuration, onBreak, task } = request;
 
-    const focusSessionState = buildFocusSessionState({ workDuration, breakDuration, onBreak, task });
+    const focusSessionState = buildFocusSessionState({
+      workDuration,
+      breakDuration,
+      onBreak,
+      task,
+    });
     const { endTime } = focusSessionState;
 
     // Clear any previous focus alarms before starting fresh

--- a/focus_bear/src/lib/__tests__/blocklist.test.ts
+++ b/focus_bear/src/lib/__tests__/blocklist.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { urlIsBlocklisted, buildBlockedUrl } from "../blocklist.js";
+
+// ─── urlIsBlocklisted ─────────────────────────────────────────────────────────
+
+describe("urlIsBlocklisted", () => {
+  it("blocks an exact hostname match", () => {
+    expect(urlIsBlocklisted("https://reddit.com/r/all", ["reddit.com"])).toEqual({
+      blocked: true,
+      host: "reddit.com",
+    });
+  });
+
+  it("blocks a subdomain when the parent domain is listed", () => {
+    expect(urlIsBlocklisted("https://www.reddit.com/r/all", ["reddit.com"])).toEqual({
+      blocked: true,
+      host: "www.reddit.com",
+    });
+  });
+
+  it("returns blocked=false for a non-matching URL", () => {
+    expect(urlIsBlocklisted("https://github.com", ["reddit.com", "twitter.com"])).toEqual({
+      blocked: false,
+      host: "github.com",
+    });
+  });
+
+  it("returns blocked=false for an empty blocklist", () => {
+    expect(urlIsBlocklisted("https://reddit.com", [])).toEqual({ blocked: false, host: "" });
+  });
+
+  it("returns blocked=false for an undefined blocklist", () => {
+    expect(urlIsBlocklisted("https://reddit.com", undefined)).toEqual({ blocked: false, host: "" });
+  });
+
+  it("does not block non-http protocols (e.g. chrome-extension://)", () => {
+    expect(urlIsBlocklisted("chrome-extension://abc123/popup.html", ["abc123"])).toEqual({
+      blocked: false,
+      host: "abc123",
+    });
+  });
+
+  it("returns blocked=false for a malformed URL", () => {
+    expect(urlIsBlocklisted("not-a-url", ["reddit.com"])).toEqual({ blocked: false, host: "" });
+  });
+
+  it("skips empty-string entries in the blocklist", () => {
+    expect(urlIsBlocklisted("https://reddit.com", ["", "reddit.com"])).toEqual({
+      blocked: true,
+      host: "reddit.com",
+    });
+  });
+
+  it("blocks the first match when multiple entries match", () => {
+    const result = urlIsBlocklisted("https://youtube.com/shorts", ["reddit.com", "youtube.com"]);
+    expect(result.blocked).toBe(true);
+    expect(result.host).toBe("youtube.com");
+  });
+
+  // Matching uses host.includes(site), so short entries match any host that contains them.
+  // This is intentional current behaviour — a test pins it so any future change to stricter
+  // (e.g. exact-domain) matching is a deliberate decision, not an accidental regression.
+  it("substring match: a short entry matches any host that contains it", () => {
+    expect(urlIsBlocklisted("https://youtube.com", ["you"])).toEqual({
+      blocked: true,
+      host: "youtube.com",
+    });
+  });
+});
+
+// ─── buildBlockedUrl ──────────────────────────────────────────────────────────
+
+describe("buildBlockedUrl", () => {
+  const BASE = "chrome-extension://abc123/blocked.html";
+
+  it("appends the host as a query param", () => {
+    expect(buildBlockedUrl(BASE, "reddit.com")).toBe(`${BASE}?d=reddit.com`);
+  });
+
+  it("URL-encodes special characters in the host", () => {
+    expect(buildBlockedUrl(BASE, "some site.com")).toBe(`${BASE}?d=some%20site.com`);
+  });
+
+  it("URL-encodes a hostname with slashes", () => {
+    expect(buildBlockedUrl(BASE, "bad/host")).toBe(`${BASE}?d=bad%2Fhost`);
+  });
+});

--- a/focus_bear/src/lib/__tests__/focus.test.ts
+++ b/focus_bear/src/lib/__tests__/focus.test.ts
@@ -71,7 +71,12 @@ describe("buildFocusSessionState", () => {
   });
 
   it("defaults task to empty string when omitted", () => {
-    const state = buildFocusSessionState({ workDuration: 60, breakDuration: 60, onBreak: false, now: NOW });
+    const state = buildFocusSessionState({
+      workDuration: 60,
+      breakDuration: 60,
+      onBreak: false,
+      now: NOW,
+    });
     expect(state.task).toBe("");
   });
 
@@ -122,7 +127,14 @@ describe("buildResumedSessionState", () => {
   const NOW = 50_000;
 
   it("recalculates endTime from saved timeLeft", () => {
-    const prev = { isRunning: false, timeLeft: 120, onBreak: false, started: true, endTime: 0, startTime: 0 };
+    const prev = {
+      isRunning: false,
+      timeLeft: 120,
+      onBreak: false,
+      started: true,
+      endTime: 0,
+      startTime: 0,
+    };
     const resumed = buildResumedSessionState(prev, NOW);
     expect(resumed.isRunning).toBe(true);
     expect(resumed.startTime).toBe(NOW);
@@ -130,7 +142,14 @@ describe("buildResumedSessionState", () => {
   });
 
   it("preserves onBreak from the previous state", () => {
-    const prev = { isRunning: false, timeLeft: 60, onBreak: true, started: true, endTime: 0, startTime: 0 };
+    const prev = {
+      isRunning: false,
+      timeLeft: 60,
+      onBreak: true,
+      started: true,
+      endTime: 0,
+      startTime: 0,
+    };
     expect(buildResumedSessionState(prev, NOW).onBreak).toBe(true);
   });
 

--- a/focus_bear/src/lib/__tests__/focus.test.ts
+++ b/focus_bear/src/lib/__tests__/focus.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  isFocusActive,
+  buildFocusSessionState,
+  computeTimeLeft,
+  buildResumedSessionState,
+} from "../focus.js";
+
+// ─── isFocusActive ────────────────────────────────────────────────────────────
+
+describe("isFocusActive", () => {
+  it("returns true when started and not on break", () => {
+    expect(isFocusActive({ started: true, onBreak: false })).toBe(true);
+  });
+
+  it("returns true when onBreak is undefined (not set)", () => {
+    expect(isFocusActive({ started: true })).toBe(true);
+  });
+
+  it("returns false when on break", () => {
+    expect(isFocusActive({ started: true, onBreak: true })).toBe(false);
+  });
+
+  it("returns false when not started", () => {
+    expect(isFocusActive({ started: false })).toBe(false);
+  });
+
+  it("returns false for undefined state (no session)", () => {
+    expect(isFocusActive(undefined)).toBe(false);
+  });
+
+  it("returns false for empty state object", () => {
+    expect(isFocusActive({})).toBe(false);
+  });
+
+  // Pausing sets isRunning=false but leaves started=true, onBreak=false.
+  // Blocking should stay active while paused — isFocusActive intentionally ignores isRunning.
+  it("returns true for a paused session (isRunning=false does not disable blocking)", () => {
+    expect(isFocusActive({ started: true, onBreak: false, isRunning: false })).toBe(true);
+  });
+});
+
+// ─── buildFocusSessionState ───────────────────────────────────────────────────
+
+describe("buildFocusSessionState", () => {
+  const NOW = 1_000_000;
+
+  it("builds a work-phase session with correct endTime", () => {
+    const state = buildFocusSessionState({
+      workDuration: 25 * 60, // 25 min in seconds
+      breakDuration: 5 * 60,
+      onBreak: false,
+      now: NOW,
+    });
+    expect(state.started).toBe(true);
+    expect(state.isRunning).toBe(true);
+    expect(state.onBreak).toBe(false);
+    expect(state.startTime).toBe(NOW);
+    expect(state.endTime).toBe(NOW + 25 * 60 * 1000);
+  });
+
+  it("builds a break-phase session using breakDuration", () => {
+    const state = buildFocusSessionState({
+      workDuration: 25 * 60,
+      breakDuration: 5 * 60,
+      onBreak: true,
+      now: NOW,
+    });
+    expect(state.onBreak).toBe(true);
+    expect(state.endTime).toBe(NOW + 5 * 60 * 1000);
+  });
+
+  it("defaults task to empty string when omitted", () => {
+    const state = buildFocusSessionState({ workDuration: 60, breakDuration: 60, onBreak: false, now: NOW });
+    expect(state.task).toBe("");
+  });
+
+  it("preserves a provided task label", () => {
+    const state = buildFocusSessionState({
+      workDuration: 60,
+      breakDuration: 60,
+      onBreak: false,
+      task: "Write tests",
+      now: NOW,
+    });
+    expect(state.task).toBe("Write tests");
+  });
+
+  // workDuration and breakDuration are read back from state by the alarm handler
+  // when transitioning between work and break phases — must not be dropped or swapped.
+  it("stores both workDuration and breakDuration in state", () => {
+    const state = buildFocusSessionState({
+      workDuration: 25 * 60,
+      breakDuration: 5 * 60,
+      onBreak: false,
+      now: NOW,
+    });
+    expect(state.workDuration).toBe(25 * 60);
+    expect(state.breakDuration).toBe(5 * 60);
+  });
+});
+
+// ─── computeTimeLeft ──────────────────────────────────────────────────────────
+
+describe("computeTimeLeft", () => {
+  it("returns remaining seconds correctly", () => {
+    expect(computeTimeLeft({ endTime: 10_000 }, 7_000)).toBe(3);
+  });
+
+  it("returns 0 when session has already expired", () => {
+    expect(computeTimeLeft({ endTime: 1_000 }, 5_000)).toBe(0);
+  });
+
+  it("returns 0 when exactly at endTime (no negative time)", () => {
+    expect(computeTimeLeft({ endTime: 5_000 }, 5_000)).toBe(0);
+  });
+});
+
+// ─── buildResumedSessionState ─────────────────────────────────────────────────
+
+describe("buildResumedSessionState", () => {
+  const NOW = 50_000;
+
+  it("recalculates endTime from saved timeLeft", () => {
+    const prev = { isRunning: false, timeLeft: 120, onBreak: false, started: true, endTime: 0, startTime: 0 };
+    const resumed = buildResumedSessionState(prev, NOW);
+    expect(resumed.isRunning).toBe(true);
+    expect(resumed.startTime).toBe(NOW);
+    expect(resumed.endTime).toBe(NOW + 120 * 1000);
+  });
+
+  it("preserves onBreak from the previous state", () => {
+    const prev = { isRunning: false, timeLeft: 60, onBreak: true, started: true, endTime: 0, startTime: 0 };
+    expect(buildResumedSessionState(prev, NOW).onBreak).toBe(true);
+  });
+
+  it("preserves task label from the previous state", () => {
+    const prev = { isRunning: false, timeLeft: 60, task: "Deep work", endTime: 0, startTime: 0 };
+    expect(buildResumedSessionState(prev, NOW).task).toBe("Deep work");
+  });
+});
+
+// ─── Pause → resume round trip ────────────────────────────────────────────────
+
+describe("pause → resume round trip", () => {
+  it("resuming after a pause preserves the correct remaining time", () => {
+    // Start a 25-minute work session at t=0
+    const session = buildFocusSessionState({
+      workDuration: 25 * 60,
+      breakDuration: 5 * 60,
+      onBreak: false,
+      now: 0,
+    });
+
+    // 5 minutes pass, then the user pauses — 20 minutes should remain
+    const PAUSED_AT = 5 * 60 * 1000;
+    const timeLeft = computeTimeLeft(session, PAUSED_AT);
+    expect(timeLeft).toBe(20 * 60);
+
+    const paused = { ...session, isRunning: false, timeLeft };
+
+    // 2 minutes later the user resumes — endTime should be 20 minutes from now
+    const RESUMED_AT = PAUSED_AT + 2 * 60 * 1000;
+    const resumed = buildResumedSessionState(paused, RESUMED_AT);
+
+    expect(resumed.isRunning).toBe(true);
+    expect(resumed.endTime).toBe(RESUMED_AT + 20 * 60 * 1000);
+  });
+});

--- a/focus_bear/src/lib/__tests__/unfocus.test.ts
+++ b/focus_bear/src/lib/__tests__/unfocus.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { computeUnfocusEndTime, isUnfocusSessionActive } from "../unfocus.js";
+
+// ─── computeUnfocusEndTime ────────────────────────────────────────────────────
+
+describe("computeUnfocusEndTime", () => {
+  it("converts minutes to milliseconds and adds to start time", () => {
+    const start = 1_000_000;
+    expect(computeUnfocusEndTime(start, 30)).toBe(start + 30 * 60 * 1000);
+  });
+
+  it("handles a 1-minute session", () => {
+    expect(computeUnfocusEndTime(0, 1)).toBe(60_000);
+  });
+
+  it("handles 0 duration (end time equals start time)", () => {
+    expect(computeUnfocusEndTime(5_000, 0)).toBe(5_000);
+  });
+});
+
+// ─── isUnfocusSessionActive ───────────────────────────────────────────────────
+
+describe("isUnfocusSessionActive", () => {
+  it("returns true when current time is before endTime", () => {
+    expect(isUnfocusSessionActive(10_000, 5_000)).toBe(true);
+  });
+
+  it("returns false when current time equals endTime (expired)", () => {
+    expect(isUnfocusSessionActive(5_000, 5_000)).toBe(false);
+  });
+
+  it("returns false when current time is past endTime", () => {
+    expect(isUnfocusSessionActive(3_000, 8_000)).toBe(false);
+  });
+});

--- a/focus_bear/src/lib/blocklist.ts
+++ b/focus_bear/src/lib/blocklist.ts
@@ -1,0 +1,23 @@
+/** Check whether a URL's hostname matches any entry in the blocklist. */
+export function urlIsBlocklisted(
+  url: string,
+  blocklist: string[] | undefined,
+): { blocked: boolean; host: string } {
+  if (!blocklist || blocklist.length === 0) return { blocked: false, host: "" };
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return { blocked: false, host: parsed.hostname };
+    }
+    const host = parsed.hostname;
+    const blocked = blocklist.some((site) => site && host.includes(site));
+    return { blocked, host };
+  } catch {
+    return { blocked: false, host: "" };
+  }
+}
+
+/** Build the redirect URL for a blocked site. blockedPage is chrome.runtime.getURL("blocked.html"). */
+export function buildBlockedUrl(blockedPage: string, host: string): string {
+  return blockedPage + "?d=" + encodeURIComponent(host);
+}

--- a/focus_bear/src/lib/focus.ts
+++ b/focus_bear/src/lib/focus.ts
@@ -1,0 +1,50 @@
+export type FocusSessionState = {
+  started?: boolean;
+  onBreak?: boolean;
+  isRunning?: boolean;
+  workDuration?: number;
+  breakDuration?: number;
+  startTime?: number;
+  endTime?: number;
+  timeLeft?: number;
+  task?: string;
+};
+
+/** True only when a focus session is actively running — not on break, not paused, not absent. */
+export function isFocusActive(state: FocusSessionState | undefined): boolean {
+  return !!(state && state.started === true && state.onBreak !== true);
+}
+
+/** Build the initial state object when starting a new focus session. */
+export function buildFocusSessionState(params: {
+  workDuration: number;
+  breakDuration: number;
+  onBreak: boolean;
+  task?: string;
+  now?: number;
+}): FocusSessionState {
+  const now = params.now ?? Date.now();
+  const duration = params.onBreak ? params.breakDuration : params.workDuration;
+  return {
+    task: params.task ?? "",
+    workDuration: params.workDuration,
+    breakDuration: params.breakDuration,
+    startTime: now,
+    endTime: now + duration * 1000,
+    isRunning: true,
+    onBreak: params.onBreak,
+    started: true,
+  };
+}
+
+/** Compute remaining seconds to snapshot when pausing a session. */
+export function computeTimeLeft(state: FocusSessionState, now?: number): number {
+  return Math.max(Math.floor(((state.endTime ?? 0) - (now ?? Date.now())) / 1000), 0);
+}
+
+/** Build the updated state when resuming a previously paused session. */
+export function buildResumedSessionState(prev: FocusSessionState, now?: number): FocusSessionState {
+  const t = now ?? Date.now();
+  const endTime = t + (prev.timeLeft ?? 0) * 1000;
+  return { ...prev, startTime: t, endTime, isRunning: true };
+}

--- a/focus_bear/src/lib/unfocus.ts
+++ b/focus_bear/src/lib/unfocus.ts
@@ -1,0 +1,9 @@
+/** Compute when (ms since epoch) an unfocus session expires. Duration is in minutes. */
+export function computeUnfocusEndTime(unfocusStart: number, unfocusDurationMinutes: number): number {
+  return unfocusStart + unfocusDurationMinutes * 60 * 1000;
+}
+
+/** True if the unfocus session has not yet expired. */
+export function isUnfocusSessionActive(endTime: number, now?: number): boolean {
+  return (now ?? Date.now()) < endTime;
+}

--- a/focus_bear/src/lib/unfocus.ts
+++ b/focus_bear/src/lib/unfocus.ts
@@ -1,5 +1,8 @@
 /** Compute when (ms since epoch) an unfocus session expires. Duration is in minutes. */
-export function computeUnfocusEndTime(unfocusStart: number, unfocusDurationMinutes: number): number {
+export function computeUnfocusEndTime(
+  unfocusStart: number,
+  unfocusDurationMinutes: number,
+): number {
   return unfocusStart + unfocusDurationMinutes * 60 * 1000;
 }
 

--- a/focus_bear/src/popup.tsx
+++ b/focus_bear/src/popup.tsx
@@ -150,9 +150,9 @@ const App = () => {
   const [redditBlurHomeFeed, setRedditBlurHomeFeed] = useState(true);
   const [redditBlurCommunities, setRedditBlurCommunities] = useState(true);
   const [redditBlurComments, setRedditBlurComments] = useState(true);
-  const [xBlurHomeFeed, setXBlurHomeFeed] = useState(true);
-  const [xBlurRecommendations, setXBlurRecommendations] = useState(true);
-  const [xBlurReplies, setXBlurReplies] = useState(true);
+  const [_xBlurHomeFeed, setXBlurHomeFeed] = useState(true);
+  const [_xBlurRecommendations, setXBlurRecommendations] = useState(true);
+  const [_xBlurReplies, setXBlurReplies] = useState(true);
 
   const [currentTab, setCurrentTab] = useState<"timer" | "active">("timer");
   const [settingsTab, setSettingsTab] = useState<"blurring" | "blocklist">("blurring");
@@ -216,13 +216,9 @@ const App = () => {
         gmailBlurEnabled,
         promotionBlurEnabled,
         socialBlurEnabled,
-        redditBlurHomeFeed,
-        redditBlurCommunities,
-        redditBlurCommeents,
         xBlurHomeFeed: storedXBlurHomeFeed,
         xBlurRecommendations: storedXBlurRecommendations,
         xBlurReplies: storedXBlurReplies,
-
       }) => {
         setBlurEnabled(blurEnabled ?? true);
         setHidden(commentsHidden ?? true);

--- a/focus_bear/src/reddit/reddit.ts
+++ b/focus_bear/src/reddit/reddit.ts
@@ -27,7 +27,7 @@
       '[data-testid="post-container"]',
       ".Post",
       "shreddit-ad-post",
-      '[data-adclicklocation]',
+      "[data-adclicklocation]",
       '[data-testid="ad-post"]',
     ];
     selectors.forEach((sel) => {
@@ -58,11 +58,7 @@
   // Blur comments section (only on post pages)
   const setBlurComments = (enabled: boolean) => {
     if (!isPostPage()) return;
-    const selectors = [
-      "shreddit-comment-tree",
-      '[data-testid="comment"]',
-      ".Comment",
-    ];
+    const selectors = ["shreddit-comment-tree", '[data-testid="comment"]', ".Comment"];
     selectors.forEach((sel) => {
       document.querySelectorAll<HTMLElement>(sel).forEach((el) => {
         if (enabled) el.classList.add(BLUR_CLASS);

--- a/focus_bear/src/x/x.ts
+++ b/focus_bear/src/x/x.ts
@@ -18,11 +18,7 @@
   };
 
   const setBlurHomeFeed = (enabled: boolean) => {
-    const selectors = [
-      'article',
-      '[data-testid="tweet"]',
-      '[data-testid="tweetText"]',
-    ];
+    const selectors = ["article", '[data-testid="tweet"]', '[data-testid="tweetText"]'];
     selectors.forEach((sel) => {
       document.querySelectorAll<HTMLElement>(sel).forEach((el) => {
         if (enabled) el.classList.add(BLUR_CLASS);
@@ -32,9 +28,7 @@
   };
 
   const setBlurRecommendations = (enabled: boolean) => {
-    const selectors = [
-      '[data-testid="sidebarColumn"]',
-    ];
+    const selectors = ['[data-testid="sidebarColumn"]'];
     selectors.forEach((sel) => {
       document.querySelectorAll<HTMLElement>(sel).forEach((el) => {
         if (enabled) el.classList.add(BLUR_CLASS);
@@ -44,10 +38,7 @@
   };
 
   const setBlurReplies = (enabled: boolean) => {
-    const selectors = [
-      '[data-testid="reply"]',
-      '[aria-label="Timeline: Conversation"] article',
-    ];
+    const selectors = ['[data-testid="reply"]', '[aria-label="Timeline: Conversation"] article'];
     selectors.forEach((sel) => {
       document.querySelectorAll<HTMLElement>(sel).forEach((el) => {
         if (enabled) el.classList.add(BLUR_CLASS);

--- a/focus_bear/vitest.config.ts
+++ b/focus_bear/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Summary
Extracted pure business logic from background.ts into src/lib/ so it can be tested without Chrome API dependencies. Added Vitest and wrote 38 unit tests covering focus session state, blocklist URL matching, and unfocus timing.

Test plan
npm test — all 38 tests pass
npm run build — extension builds without errors