### PR TITLE
feat: add test job to CI workflow (issue #91)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,3 +44,22 @@ jobs:
 
       - name: Check formatting
         run: npx oxfmt --check .
+
+test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: focus_bear
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: focus_bear/package-lock.json
+      - run: npm ci
+      - name: Run tests
+        run: npm test
+
+        


### PR DESCRIPTION
Add a test job to the existing CI workflow so that tests must pass before any PR can be merged into main.

- Added a third job called 'test' to .github/workflows/lint.yml
- Follows the exact same structure as oxlint and oxfmt jobs (same runs-on, working-directory, Node setup and npm ci step)
- Final step runs: npm test
- Test job runs in parallel with oxlint and oxfmt

Closes #91